### PR TITLE
Document the required ATL and MFC build components

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.VCTools",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.ATLMFC"
+  ]
+}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -12,6 +12,7 @@
 | Host and architecture | Windows, 32-bit (`Win32`) target |
 | Processor | SSE2, so a Pentium 4 or Athlon 64 onward |
 | Generator and compiler | Visual Studio 2022 MSVC 19.30 or newer |
+| ATL and MFC | The Visual Studio C++ ATL and C++ MFC components |
 | Windows SDK | A Visual Studio-installed Windows SDK |
 | CMake | 3.23 or newer |
 | C++ language level | C++20 |
@@ -22,6 +23,14 @@ supported by the current tree.
 
 Install Visual Studio 2022 with the **Desktop development with C++** workload,
 a Windows SDK, CMake 3.23 or newer, and Git for Windows.
+
+The workload alone is not sufficient, even with its recommended components: the
+engine includes `atlbase.h` and its resource scripts include `afxres.h`, so the
+**C++ ATL** and **C++ MFC** components for the current build tools must be
+selected as well. In an unattended install, these are
+`Microsoft.VisualStudio.Component.VC.ATL` and
+`Microsoft.VisualStudio.Component.VC.ATLMFC`. Without them the build fails at
+`code/wonline.cpp` and `code/Sun.rc`.
 
 ## Dependencies
 
@@ -146,6 +155,13 @@ Studio 2022 Community 17.14.37328.6, MSVC 19.44.35228, and Windows SDK
 10.0.26100. Fresh Win32 Debug and Release builds completed successfully. The
 builds retain inherited MSVC warnings; warnings are not treated as errors, but
 contributions should not add new warnings.
+
+The ATL and MFC requirement was established on August 27, 2026 with MSVC
+19.44.35228, Windows SDK 10.0.26100, and CMake 4.4.2: a fresh Visual Studio
+2022 Build Tools install with only the **Desktop development with C++**
+workload and its recommended components failed to build, first at
+`code/wonline.cpp` on the missing `atlbase.h` and, with ATL added, at
+`code/Sun.rc` on the missing `afxres.h`.
 
 Build verification establishes that the supported toolchain compiles and links
 the configured targets and produces the listed artifacts. Runtime behavior is

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -32,6 +32,12 @@ selected as well. In an unattended install, these are
 `Microsoft.VisualStudio.Component.VC.ATLMFC`. Without them the build fails at
 `code/wonline.cpp` and `code/Sun.rc`.
 
+`.vsconfig` at the repository root records the workload and both components in
+the Visual Studio installation configuration format. Importing it in the Visual
+Studio Installer, or passing it to an unattended install with `--config`,
+selects them in one step, and Visual Studio offers to install missing listed
+components when it detects the file near an open solution or folder.
+
 ## Dependencies
 
 The renderer is built on [bgfx](https://github.com/bkaradzic/bgfx), vendored as the

--- a/manual/content/using/build-and-run.md
+++ b/manual/content/using/build-and-run.md
@@ -13,7 +13,7 @@ related:
     id: developer-build-troubleshooting
 ---
 
-Install Visual Studio 2022 with the **Desktop development with C++** workload, a Windows SDK, CMake 3.23 or newer, and Git for Windows. The repository's `docs/BUILDING.md` covers toolchain details and options.
+Install Visual Studio 2022 with the **Desktop development with C++** workload, its **C++ ATL** and **C++ MFC** components — the workload does not select them on its own — a Windows SDK, CMake 3.23 or newer, and Git for Windows. The repository's `docs/BUILDING.md` covers toolchain details and options.
 
 The renderer is a vendored dependency, so a clone that did not fetch submodules has to fetch them before configuring. Configuration stops with instructions if they are missing.
 


### PR DESCRIPTION
## Summary

A fresh Visual Studio 2022 Build Tools install with only the **Desktop development with C++** workload (`Microsoft.VisualStudio.Workload.VCTools --includeRecommended`) cannot build OpenTS: `code/wonline.cpp` includes `atlbase.h`, which requires `Microsoft.VisualStudio.Component.VC.ATL`, and `code/Sun.rc` includes `afxres.h`, which requires `Microsoft.VisualStudio.Component.VC.ATLMFC`. Neither component is selected by the workload, and `docs/BUILDING.md` did not mention them. This change documents both components as build requirements.

## Classification

Documentation-only. No engine behavior, interface, or compatibility boundary is affected.

## Validation

- Requirement evidence (August 27, 2026; MSVC 19.44.35228, Windows SDK 10.0.26100, CMake 4.4.2): a fresh VS 2022 Build Tools install with only the workload and its recommended components failed to build, first at `code/wonline.cpp` on the missing `atlbase.h` and, with ATL added, at `code/Sun.rc` on the missing `afxres.h`.
- `python manual/tools/manage.py check`: extraction, catalog, route, contract, lifecycle, and source-link checks passed with zero catalog deltas. The site-build step did not run because the machine lacks Node/npm.
- No engine build was run for this change itself, as it touches only documentation.

## Documentation

- `docs/BUILDING.md` (owner of build support): adds an ATL and MFC row to the supported-target table, extends the install paragraph with the two components and their unattended-install IDs, and records the evidence in the verification boundary.
- `manual/content/using/build-and-run.md`: the install sentence now names both components; toolchain detail remains owned by `docs/BUILDING.md`, which the page links.