### PR TITLE
[Vanilla Bugfix] Fix Buggy Spotlight Behavior w/Event 35 - Enemy In Spotlight

### DIFF
--- a/code/blight.cpp
+++ b/code/blight.cpp
@@ -56,7 +56,6 @@ BuildingLightClass::BuildingLightClass(TechnoClass * owner) :
 	RotationPivot(COORD_NONE),
 	RotationTarget(COORD_NONE),
 	Acceleration(0),
-	IsDetectionSource(false),
 	IsOppositeDirection(false),
 	Behavior(0),
 	Target(NULL),
@@ -277,12 +276,8 @@ void BuildingLightClass::AI(void)
 			}
 
 			if (found) {
-				IsDetectionSource = true;
-
 				owner_building->Tag->Spring(TEVENT_ENEMY_IN_SPOTLIGHT, owner_building);
 				owner_building->Tag->Spring(TEVENT_ENEMY_IN_SPOTLIGHT_REPEATING, owner_building);
-
-				IsDetectionSource = false;
 			}
 		}
 	}

--- a/code/blight.cpp
+++ b/code/blight.cpp
@@ -56,6 +56,7 @@ BuildingLightClass::BuildingLightClass(TechnoClass * owner) :
 	RotationPivot(COORD_NONE),
 	RotationTarget(COORD_NONE),
 	Acceleration(0),
+	IsDetectionSource(false),
 	IsOppositeDirection(false),
 	Behavior(0),
 	Target(NULL),
@@ -177,6 +178,8 @@ void BuildingLightClass::AI(void)
 		return;
 	}
 
+	bool resumed_sweep = false;
+
 	Coord coord = PositionCoord;
 	switch (Behavior) {
 		default:
@@ -188,6 +191,8 @@ void BuildingLightClass::AI(void)
 				coord = Lerp(PositionCoord, Target->PositionCoord, 0.25);
 			} else {
 				Set_Behavior_Type(LIGHT_BEHAVIOR_SWEEP);
+
+				resumed_sweep = true;
 			}
 			break;
 
@@ -248,7 +253,7 @@ void BuildingLightClass::AI(void)
 
 	BuildingClass * owner_building = (Owner->RTTI == RTTI_BUILDING) ? (BuildingClass *)Owner : NULL;
 
-	if (Behavior == LIGHT_BEHAVIOR_SWEEP) {
+	if (Behavior == LIGHT_BEHAVIOR_SWEEP && !resumed_sweep) {
 		if (owner_building != NULL && owner_building->IsActive && owner_building->Is_Powered_On() && owner_building->Tag != NULL) {
 			bool found = false;
 			Cell cell = PositionCell;
@@ -272,8 +277,12 @@ void BuildingLightClass::AI(void)
 			}
 
 			if (found) {
+				IsDetectionSource = true;
+
 				owner_building->Tag->Spring(TEVENT_ENEMY_IN_SPOTLIGHT, owner_building);
 				owner_building->Tag->Spring(TEVENT_ENEMY_IN_SPOTLIGHT_REPEATING, owner_building);
+
+				IsDetectionSource = false;
 			}
 		}
 	}

--- a/code/blight.h
+++ b/code/blight.h
@@ -90,13 +90,6 @@ class BuildingLightClass : public ObjectClass
 		double Acceleration;
 
 		/*
-		 * Used to ensure that Follow behavior is only applied to the
-		 * spotlight that actually detected the enemy, rather than to
-		 * other spotlights sharing the same trigger/tag.
-		 */
-		bool IsDetectionSource;
-
-		/*
 		 * If the beam is sweeping back the other way along its arc, then this flag will be
 		 * true. Alternate lights are created with it already set, so that a row of spotlights
 		 * does not swing in unison.

--- a/code/blight.h
+++ b/code/blight.h
@@ -90,6 +90,13 @@ class BuildingLightClass : public ObjectClass
 		double Acceleration;
 
 		/*
+		 * Used to ensure that Follow behavior is only applied to the
+		 * spotlight that actually detected the enemy, rather than to
+		 * other spotlights sharing the same trigger/tag.
+		 */
+		bool IsDetectionSource;
+
+		/*
 		 * If the beam is sweeping back the other way along its arc, then this flag will be
 		 * true. Alternate lights are created with it already set, so that a row of spotlights
 		 * does not swing in unison.

--- a/code/taction.cpp
+++ b/code/taction.cpp
@@ -85,6 +85,7 @@
 #include "tagtype.h"
 #include "team.h"
 #include "teamtype.h"
+#include "tevent.h"
 #include "theme.h"
 #include "tracker.h"
 #include "trigger.h"
@@ -2045,8 +2046,47 @@ bool TActionClass::TAction_RESHROUD(HouseClass * , ObjectClass * , TriggerClass 
 /// the new behavior, so a scenario can have the searchlights start hunting on cue.
 /// </summary>
 /// <returns>bool; Was at least one spotlight changed?</returns>
-bool TActionClass::TAction_CHANGE_SPOTLIGHT_BEHAVIOR(HouseClass * , ObjectClass * , TriggerClass * trig, Cell const & )
+bool TActionClass::TAction_CHANGE_SPOTLIGHT_BEHAVIOR(HouseClass * , ObjectClass * object, TriggerClass * trig, Cell const & )
 {
+	bool spotlight_event = false;
+
+	if (trig != NULL && trig->Class != NULL) {
+		TEventClass* tevent = trig->Class->FirstEvent;
+
+		while (tevent != NULL) {
+			if (tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT || tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT_REPEATING) {
+
+				spotlight_event = true;
+				break;
+			}
+
+			tevent = tevent->Next;
+		}
+	}
+
+	if (Data.LightBehavior == LIGHT_BEHAVIOR_FOLLOW && spotlight_event) {
+		if (object == NULL || object->RTTI != RTTI_BUILDING) {
+			return(false);
+		}
+
+		BuildingClass* building = (BuildingClass*)object;
+
+		if (building->Strength > 0 &&
+				building->IsActive &&
+				building->IsDown &&
+				!building->IsInLimbo &&
+				building->Class->HasSpotlight &&
+				building->BuildingLight != NULL &&
+				building->BuildingLight->IsDetectionSource) {
+
+			building->BuildingLight->Set_Behavior_Type(LIGHT_BEHAVIOR_FOLLOW);
+
+			return(true);
+		}
+
+		return(false);
+	}
+
 	bool success = false;
 	for (int index = 0; index < Buildings.Count(); index++) {
 		BuildingClass * ptr = Buildings[index];

--- a/code/taction.cpp
+++ b/code/taction.cpp
@@ -2046,62 +2046,33 @@ bool TActionClass::TAction_RESHROUD(HouseClass * , ObjectClass * , TriggerClass 
 /// the new behavior, so a scenario can have the searchlights start hunting on cue.
 /// </summary>
 /// <returns>bool; Was at least one spotlight changed?</returns>
-bool TActionClass::TAction_CHANGE_SPOTLIGHT_BEHAVIOR(HouseClass * , ObjectClass * object, TriggerClass * trig, Cell const & )
+bool TActionClass::TAction_CHANGE_SPOTLIGHT_BEHAVIOR(HouseClass*, ObjectClass* object, TriggerClass* trig, Cell const&)
 {
-	bool spotlight_event = false;
-
-	if (trig != NULL && trig->Class != NULL) {
-		TEventClass* tevent = trig->Class->FirstEvent;
-
-		while (tevent != NULL) {
-			if (tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT || tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT_REPEATING) {
-
-				spotlight_event = true;
-				break;
-			}
-
-			tevent = tevent->Next;
-		}
-	}
-
-	if (Data.LightBehavior == LIGHT_BEHAVIOR_FOLLOW && spotlight_event) {
-		if (object == NULL || object->RTTI != RTTI_BUILDING) {
-			return(false);
-		}
-
-		BuildingClass* building = (BuildingClass*)object;
-
-		if (building->Strength > 0 &&
-				building->IsActive &&
-				building->IsDown &&
-				!building->IsInLimbo &&
-				building->Class->HasSpotlight &&
-				building->BuildingLight != NULL &&
-				building->BuildingLight->IsDetectionSource) {
-
-			building->BuildingLight->Set_Behavior_Type(LIGHT_BEHAVIOR_FOLLOW);
-
-			return(true);
-		}
-
-		return(false);
-	}
+	bool restrict_to_source =
+		Data.LightBehavior == LIGHT_BEHAVIOR_FOLLOW &&
+		object != NULL &&
+		object->RTTI == RTTI_BUILDING;
 
 	bool success = false;
+
 	for (int index = 0; index < Buildings.Count(); index++) {
-		BuildingClass * ptr = Buildings[index];
+		BuildingClass* ptr = Buildings[index];
+
 		if (ptr->Strength > 0 &&
-				ptr->IsActive &&
-				ptr->IsDown &&
-				!ptr->IsInLimbo &&
-				ptr->Class->HasSpotlight &&
-				ptr->BuildingLight != NULL &&
-				ptr->Tag != NULL &&
-				ptr->Tag->Is_Trigger_Attached(trig)) {
+			ptr->IsActive &&
+			ptr->IsDown &&
+			!ptr->IsInLimbo &&
+			ptr->Class->HasSpotlight &&
+			ptr->BuildingLight != NULL &&
+			ptr->Tag != NULL &&
+			ptr->Tag->Is_Trigger_Attached(trig) &&
+			(!restrict_to_source || ptr == object)) {
+
 			ptr->BuildingLight->Set_Behavior_Type(Data.LightBehavior);
 			success = true;
 		}
 	}
+
 	return(success);
 }
 

--- a/code/trigger.cpp
+++ b/code/trigger.cpp
@@ -293,7 +293,13 @@ bool TriggerClass::Should_Spring(TEventType event, ObjectClass * object, bool fo
 		TEventClass * tevent = Class->FirstEvent;
 		int index = 0;
 		while (tevent != NULL) {
-			if (Is_Event_Tripped(index) || tevent->operator()(event, House_From_HousesType((HousesType)Class->House->HeapID), object, Timer, persistent, source)) {
+			bool event_tripped = Is_Event_Tripped(index);
+
+			if (event_tripped && tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT && Class->FirstEvent->Next == NULL && event != TEVENT_ENEMY_IN_SPOTLIGHT) {
+				event_tripped = false;
+			}
+
+			if (event_tripped || tevent->operator()(event, House_From_HousesType((HousesType)Class->House->HeapID), object, Timer, persistent, source)) {
 				if (persistent) {
 					if (tevent->Is_Time_Based() && tevent->Is_To_Flag_As_Tripped()) {
 						Flag_Event_Tripped(index);

--- a/code/trigger.cpp
+++ b/code/trigger.cpp
@@ -295,7 +295,16 @@ bool TriggerClass::Should_Spring(TEventType event, ObjectClass * object, bool fo
 		while (tevent != NULL) {
 			bool event_tripped = Is_Event_Tripped(index);
 
-			if (event_tripped && tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT && Class->FirstEvent->Next == NULL && event != TEVENT_ENEMY_IN_SPOTLIGHT) {
+			/*
+			** A latched event only helps a persistent trigger when another event
+			** still needs to be satisfied. Keep this exception scoped to Event 35
+			** rather than changing latch behavior for other trigger events.
+			*/
+			if (event_tripped &&
+				tevent->Event == TEVENT_ENEMY_IN_SPOTLIGHT &&
+				index == 0 &&
+				tevent->Next == NULL &&
+				event != TEVENT_ENEMY_IN_SPOTLIGHT) {
 				event_tripped = false;
 			}
 


### PR DESCRIPTION
## Summary

<!-- What changed, why, and what outcome should reviewers expect? -->

This PR fixes several spotlight trigger issues affecting `Enemy In Spotlight (Event 35)`. This is much more noticeable when multiple light towers share the same tag.

It changes spotlight Follow handling so only the tower that actually detected the enemy begins tracking it, prevents a Follow-to-Sweep transition from immediately re-detecting in the same frame, and stops a latched single-event Event 35 trigger from firing again on unrelated event polls.

Reviewers should expect more stable spotlight behavior with shared tags. There shouldn't be unrelated tower spotlight position resetting or spazzing (when under repeated fire), and there shouldn't be anymore repeated trigger spam after a prior detection. Event 35’s existing persistent/multi-event latching behavior remains intact.

**Video of the Issue:**

https://github.com/user-attachments/assets/60c25999-adec-42bf-bbcb-d3426ad3f8f7


## Behavior and compatibility

<!--
Classify this as preserved behavior, a bug fix, or an intentional behavior
change. Identify affected configuration, data, mods, saves, replays, networking,
determinism, COM, or ABI boundaries. For a break, give the version and migration.
-->

**This is a Vanilla bug fix.**
Fixes incorrect `Enemy In Spotlight (Event 35)` behavior affecting shared spotlight tags and persistent triggers.

## Validation

<!-- List exact commands, configurations, environments, and results. State material checks not run. -->

**Environment:** Windows 10, Visual Studio 2022, OpenTS x86 Release build.
**Build:** cmake --build build --config Release
**Test configuration:** Two spotlight towers sharing the same tag, `Event 35 (Enemy In Spotlight)`, persistence set to Repeat, with `Change Spotlight Behavior -> Follow`.
**Result:** Verified that only the detecting spotlight enters Follow, the second spotlight continues sweeping without resetting, Follow returns to Sweep without looping/re-triggering, and subsequent unrelated attacks do not cause repeated Event 35 activations.

**Video of the fix:**

https://github.com/user-attachments/assets/6586384f-848e-4e60-b291-3328039740dc

## Documentation

<!-- Link the updated owning documentation, or explain why no update is needed. -->

## Checklist

- [x] The change is focused; unrelated mechanical cleanup is separate
- [x] Compatibility effects and any migration are explicit
- [x] Validation distinguishes what passed, failed, and was not run
- [x] No prohibited assets, binaries, SDKs, credentials, or generated output are included
