### PR TITLE
Do not render sidebar over menu dialog windows

### DIFF
--- a/code/winstub.cpp
+++ b/code/winstub.cpp
@@ -249,8 +249,8 @@ LRESULT CALLBACK /*_export*/ Windows_Procedure(HWND hwnd, UINT message, UINT wPa
 			if (GameInFocus == true || WindowedMode == true) {
 				if (MouseCursor != NULL && VisibleSurface != NULL && HiddenSurface != NULL && CompositeSurface != NULL) {
 					if (ScenarioActive == true) {
-						Update_Visible_Surface(CompositeSurface);
 						Map.Blit_Sidebar(true);
+						Update_Visible_Surface(CompositeSurface);
 					} else if (Movie_Is_Playing() == true) {
 						Movie_Update_Visible_Surface();
 					} else {


### PR DESCRIPTION
## Summary
Flip rendering order of sidebar and dialog windows when handling WM_PAINT to not overdraw the dialog. The sidebar painting is needed in this place to prevent rendering artifacts when changing between different menu dialogs. While the game is running the rendering of sidebar is handled elsewhere. 

## Behavior and compatibility

Bug fix to restore original behaviour and remove graphical artifacts. 

## Validation

Manual testing in GDI1 and skirmish mode. 

## Documentation

N/A, small visual change to restore original behaviour.

## Checklist

- [X] The change is focused; unrelated mechanical cleanup is separate
- [X] Compatibility effects and any migration are explicit
- [X] Validation distinguishes what passed, failed, and was not run
- [X] No prohibited assets, binaries, SDKs, credentials, or generated output are included
