### PR TITLE
Visual Studio Code support/configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,11 @@ cmake_install.cmake
 *.swp
 *.code-workspace
 .idea/
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/settings.json
 .history/
 /.cache/
 /.clangd

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,4 @@
 {
-  // Recommended extensions for OpenTS. .vscode/ is gitignored, so this is local.
   "recommendations": [
     "ms-vscode.cmake-tools",
     "ms-vscode.cpptools",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // Recommended extensions for OpenTS. .vscode/ is gitignored, so this is local.
+  "recommendations": [
+    "ms-vscode.cmake-tools",
+    "ms-vscode.cpptools",
+    "editorconfig.editorconfig",
+    "shardulm94.trailing-spaces"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,10 +12,7 @@
       "request": "launch",
       "preLaunchTask": "Build OpenTS: Debug",
       "program": "${workspaceFolder}/Run/GameD.exe",
-      "args": [],
-      "stopAtEntry": false,
       "cwd": "${workspaceFolder}/Run",
-      "environment": [],
       "console": "internalConsole",
       "symbolSearchPath": "${workspaceFolder}/Run"
     },
@@ -25,10 +22,7 @@
       "request": "launch",
       "preLaunchTask": "Build OpenTS: Release",
       "program": "${workspaceFolder}/Run/Game.exe",
-      "args": [],
-      "stopAtEntry": false,
       "cwd": "${workspaceFolder}/Run",
-      "environment": [],
       "console": "internalConsole",
       "symbolSearchPath": "${workspaceFolder}/Run"
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+  // Local debugging configs. The builds copy the exe and PDB into Run/, and the
+  // game runs with Run/ as its working directory.
+  // - F5 runs the selected config with the debugger attached.
+  // - Ctrl+F5 runs the same config with no debugger attached (plain launch).
+  // - "Attach to running OpenTS" attaches to a game already running.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug OpenTS: Debug build (GameD.exe)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "preLaunchTask": "Build OpenTS: Debug",
+      "program": "${workspaceFolder}/Run/GameD.exe",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}/Run",
+      "environment": [],
+      "console": "internalConsole",
+      "symbolSearchPath": "${workspaceFolder}/Run"
+    },
+    {
+      "name": "Debug OpenTS: Release build (Game.exe)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "preLaunchTask": "Build OpenTS: Release",
+      "program": "${workspaceFolder}/Run/Game.exe",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}/Run",
+      "environment": [],
+      "console": "internalConsole",
+      "symbolSearchPath": "${workspaceFolder}/Run"
+    },
+    {
+      "name": "Attach to running OpenTS",
+      "type": "cppvsdbg",
+      "request": "attach",
+      "processId": "${command:pickProcess}",
+      "symbolSearchPath": "${workspaceFolder}/Run"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,6 @@
 {
-  // Local debugging configs. The builds copy the exe and PDB into Run/, and the
-  // game runs with Run/ as its working directory.
+  // The builds copy the exe and PDB into Run/, and the game runs with Run/ as
+  // its working directory.
   // - F5 runs the selected config with the debugger attached.
   // - Ctrl+F5 runs the same config with no debugger attached (plain launch).
   // - "Attach to running OpenTS" attaches to a game already running.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,9 +1,4 @@
 {
-  // The builds copy the exe and PDB into Run/, and the game runs with Run/ as
-  // its working directory.
-  // - F5 runs the selected config with the debugger attached.
-  // - Ctrl+F5 runs the same config with no debugger attached (plain launch).
-  // - "Attach to running OpenTS" attaches to a game already running.
   "version": "0.2.0",
   "configurations": [
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  // Local workspace settings for OpenTS. .vscode/ is gitignored, so this is personal.
+
+  // CMake Tools: pin the generator/platform to match docs/BUILDING.md.
+  "cmake.sourceDirectory": "${workspaceFolder}",
+  "cmake.buildDirectory": "${workspaceFolder}/build",
+  "cmake.generator": "Visual Studio 17 2022",
+  "cmake.platform": "Win32",
+  "cmake.configureOnOpen": true,
+  "cmake.buildBeforeRun": true,
+
+  // C/C++ (cpptools): use CMake Tools as the code model provider (MSVC, Win32).
+  "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+  "C_Cpp.errorSquiggles": "enabled",
+
+  // This repo uses .hh for definition headers; map them to C++.
+  "files.associations": {
+    "*.hh": "cpp",
+    "*.rh": "cpp"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  // Local workspace settings for OpenTS. .vscode/ is gitignored, so this is personal.
-
   // CMake Tools: pin the generator/platform to match docs/BUILDING.md.
   "cmake.sourceDirectory": "${workspaceFolder}",
   "cmake.buildDirectory": "${workspaceFolder}/build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-  // VS Code tasks for OpenTS. Build commands mirror docs/BUILDING.md.
-  // Note: .vscode/ is gitignored in this repo, so this file is local to your checkout.
   "version": "2.0.0",
   "tasks": [
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,67 @@
+{
+  // VS Code tasks for OpenTS. Build commands mirror docs/BUILDING.md.
+  // Note: .vscode/ is gitignored in this repo, so this file is local to your checkout.
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "CMake: Configure (Win32 VS2022)",
+      "type": "shell",
+      "command": "cmake",
+      "args": ["-S", ".", "-B", "build", "-G", "Visual Studio 17 2022", "-A", "Win32"],
+      "group": "build",
+      "detail": "Configure the Win32 Debug/Release solution into build/.",
+      "problemMatcher": []
+    },
+    {
+      "label": "Build OpenTS (pick configuration)",
+      "type": "shell",
+      "command": "cmake",
+      "args": ["--build", "build", "--config", "${input:buildConfig}"],
+      "group": { "kind": "build", "isDefault": true },
+      "dependsOn": ["CMake: Configure (Win32 VS2022)"],
+      "detail": "Build a configuration you choose.",
+      "problemMatcher": ["$msCompile"]
+    },
+    {
+      "label": "Build OpenTS: Debug",
+      "type": "shell",
+      "command": "cmake",
+      "args": ["--build", "build", "--config", "Debug"],
+      "group": "build",
+      "hide": true,
+      "dependsOn": ["CMake: Configure (Win32 VS2022)"],
+      "detail": "Hidden build used by F5 on the Debug launch config.",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "close": true
+      },
+      "problemMatcher": ["$msCompile"]
+    },
+    {
+      "label": "Build OpenTS: Release",
+      "type": "shell",
+      "command": "cmake",
+      "args": ["--build", "build", "--config", "Release"],
+      "group": "build",
+      "hide": true,
+      "dependsOn": ["CMake: Configure (Win32 VS2022)"],
+      "detail": "Hidden build used by F5 on the Release launch config.",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "close": true
+      },
+      "problemMatcher": ["$msCompile"]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "buildConfig",
+      "type": "pickString",
+      "options": ["Debug", "Release"],
+      "default": "Debug",
+      "description": "Build configuration"
+    }
+  ]
+}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -64,6 +64,16 @@ name and copy the runtime files into `TS_RUN_DIR`, which defaults to `Run/`:
 built configuration replaces the previous copy in `Run/`. Compiler and linker
 intermediates remain under the selected build directory.
 
+## Build from Visual Studio Code
+
+VSCode support includes (assuming recommended extensions are installed):
+
+- pre-configured CMake Tools settings
+- build tasks corresponding to the configs (a configure task and a config
+  picker, plus two hidden per-configuration ones backing the launch configs)
+- launch and attach configs
+- full Test Explorer integration
+
 ## Build identity
 
 The project version is declared once, by `project(OpenTS VERSION ...)` in the

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -66,13 +66,15 @@ intermediates remain under the selected build directory.
 
 ## Build from Visual Studio Code
 
-VSCode support includes (assuming recommended extensions are installed):
+Visual Studio Code (VSCode) support includes (assuming recommended extensions are installed):
 
-- pre-configured CMake Tools settings
+- pre-configured CMake Tools settings;
 - build tasks corresponding to the configs (a configure task and a config
-  picker, plus two hidden per-configuration ones backing the launch configs)
-- launch and attach configs
-- full Test Explorer integration
+  picker, plus two hidden per-configuration ones backing the launch configs);
+- launch and attach configs;
+- full Test Explorer integration.
+
+Standard VSCode shortcuts (`Ctrl+Shift+B`, `F5`, `Ctrl+F5`) and interface apply.
 
 ## Build identity
 


### PR DESCRIPTION
﻿## Summary

Includes:
- recommended extensions
- pre-configured CMake Tools extension settings
- build tasks (two hidden ones since launch configs can't target the generic one) and a configure task so build always works
- launch and attach configs
- full test explorer integration when CMake Tools are installed

Also un-ignores the four `.vscode/` files in `.gitignore`.

## Behavior and compatibility

<!--
Classify this as preserved behavior, a bug fix, or an intentional behavior
change. Identify affected configuration, data, mods, saves, replays, networking,
determinism, COM, or ABI boundaries. For a break, give the version and migration.
-->

N/A

## Validation

<!-- List exact commands, configurations, environments, and results. State material checks not run. -->

opened VSCode from a clean slate and run through/configured all the listed things, IntelliSense worked, build tasks worked, CMake configs seem to work, tests accessible and runnable

## Documentation

`docs/BUILDING.md` gained a "Build from Visual Studio Code" section covering the new `.vscode/` configuration.

## Checklist

- [x] The change is focused; unrelated mechanical cleanup is separate
- [x] Compatibility effects and any migration are explicit
- [x] A player- or modder-visible engine change carries its change record
- [x] Validation distinguishes what passed, failed, and was not run
- [x] No prohibited assets, binaries, SDKs, credentials, or generated output are included

