### PR TITLE
Define NOMINMAX for all OpenTS targets

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -171,6 +171,7 @@ target_compile_definitions(OpenTS PRIVATE
     WIN32
     _WINDOWS
     _MBCS
+    NOMINMAX
 
     # Compiles Blowfish into the binary instead of reaching it through the COM object in
     # blowfish.dll. It decides the layout of BlowfishEngine, so every translation unit has

--- a/code/always.h
+++ b/code/always.h
@@ -81,18 +81,6 @@ void __cdecl operator delete(void * ptr);
 #define WWINLINE inline
 #endif
 
-// Windows headers define 'min' and 'max' as macros, which would break every
-// std::min and std::max call in the tree.
-#define NOMINMAX
-
-#ifdef min
-#undef min
-#endif
-
-#ifdef max
-#undef max
-#endif
-
 
 /*
 **	This includes the minimum set of compiler defines and pragmas in order to bring the

--- a/code/language/CMakeLists.txt
+++ b/code/language/CMakeLists.txt
@@ -5,6 +5,7 @@ file(GLOB_RECURSE LANG_SRC CONFIGURE_DEPENDS
 
 add_library(Language SHARED ${LANG_SRC})
 target_compile_features(Language PRIVATE cxx_std_20)
+target_compile_definitions(Language PRIVATE NOMINMAX)
 
 # The version resource is stamped from the generated headers, which the resource compiler
 # reaches through the target's include paths.

--- a/code/vqalib/CMakeLists.txt
+++ b/code/vqalib/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_definitions(VQALib PRIVATE
     WIN32
     _WINDOWS
     _MBCS
+    NOMINMAX
 )
 
 # Callers reach the vqaplay.h family through the library, while the player itself reaches

--- a/tests/cpudetect/CMakeLists.txt
+++ b/tests/cpudetect/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(CpuDetect PRIVATE
     "${CMAKE_SOURCE_DIR}/code"
 )
 
-target_compile_definitions(CpuDetect PRIVATE WIN32 _WINDOWS _MBCS)
+target_compile_definitions(CpuDetect PRIVATE WIN32 _WINDOWS _MBCS NOMINMAX)
 
 # The engine builds these sources with SSE2 and precise floating point. The harness matches
 # that so a result here carries over to the engine.

--- a/tests/gamedirs/CMakeLists.txt
+++ b/tests/gamedirs/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(GameDirs PRIVATE
 
 add_dependencies(GameDirs OpenTSBuildStamp)
 
-target_compile_definitions(GameDirs PRIVATE WIN32 _WINDOWS _MBCS)
+target_compile_definitions(GameDirs PRIVATE WIN32 _WINDOWS _MBCS NOMINMAX)
 
 target_compile_options(GameDirs PRIVATE
     $<$<CONFIG:Debug>:/MTd /EHsc /Zc:__cplusplus>

--- a/tests/logstress/CMakeLists.txt
+++ b/tests/logstress/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(LogStress PRIVATE
 
 add_dependencies(LogStress OpenTSBuildStamp)
 
-target_compile_definitions(LogStress PRIVATE WIN32 _WINDOWS _MBCS)
+target_compile_definitions(LogStress PRIVATE WIN32 _WINDOWS _MBCS NOMINMAX)
 
 target_compile_options(LogStress PRIVATE
     $<$<CONFIG:Debug>:/MTd /EHsc /Zc:__cplusplus>


### PR DESCRIPTION
Defines NOMINMAX through CMake to prevent Windows macros from conflicting with `std::min` and `std::max`