### PR TITLE
Play the intro from the campaign's own disc

### DIFF
--- a/code/mixfile.cpp
+++ b/code/mixfile.cpp
@@ -520,7 +520,8 @@ void MixFileClass::Free(void)
  * HISTORY:                                                                                    *
  *   10/17/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-bool MixFileClass::Offset(char const * filename, void ** realptr, MixFileClass ** mixfile, int * offset, int * size)
+bool MixFileClass::Offset(char const * filename, void ** realptr, MixFileClass ** mixfile, int * offset,
+	int * size, MixFileSearchFilter const * filter)
 {
 	MixFileClass * ptr;
 
@@ -545,6 +546,11 @@ bool MixFileClass::Offset(char const * filename, void ** realptr, MixFileClass *
 	ptr = List.First();
 	while (ptr->Is_Valid()) {
 		SubBlock * block;
+
+		if (filter != NULL && filter->Accepts != NULL && !filter->Accepts(ptr, filter->Context)) {
+			ptr = ptr->Next();
+			continue;
+		}
 
 		/*
 		**	Binary search for the file in this mixfile. If it is found, then extract the

--- a/code/mixfile.h
+++ b/code/mixfile.h
@@ -22,6 +22,13 @@
 #include <cstdlib>
 
 class PKey;
+class MixFileClass;
+
+
+struct MixFileSearchFilter {
+	bool (*Accepts)(MixFileClass const * mixfile, void const * context);
+	void const * Context;
+};
 
 class MixFileClass : public Node<MixFileClass *>
 {
@@ -36,7 +43,9 @@ class MixFileClass : public Node<MixFileClass *>
 		void Free(void);
 		bool Cache(Buffer const * buffer = NULL);
 		static bool Cache(char const *filename, Buffer const * buffer=NULL);
-		static bool Offset(char const *filename, void ** realptr = 0, MixFileClass ** mixfile = 0, int * offset = 0, int * size = 0);
+		static MixFileClass * Finder(char const * filename);
+		static bool Offset(char const *filename, void ** realptr = 0, MixFileClass ** mixfile = 0,
+			int * offset = 0, int * size = 0, MixFileSearchFilter const * filter = NULL);
 		static void const * Retrieve(char const *filename);
 
 		struct SubBlock {
@@ -50,7 +59,6 @@ class MixFileClass : public Node<MixFileClass *>
 		};
 
 	private:
-		static MixFileClass * Finder(char const * filename);
 		int Offset(int crc, int * size = 0) const;
 
 		/*

--- a/code/movie.cpp
+++ b/code/movie.cpp
@@ -17,6 +17,7 @@
 
 #include "_keyboar.h"
 #include "_map.h"
+#include "_mixfile.h"
 #include "_rect.h"
 #include "_surface.h"
 #include "ccfile.h"
@@ -25,6 +26,7 @@
 #include "globals.h"
 #include "goptions.h"
 #include "gscreen.h"
+#include "mixfile.h"
 #include "movies.h"
 #include "session.h"
 #include "vector.h"
@@ -74,7 +76,8 @@ unsigned			PaletteCounter;
  * HISTORY:                                                                                    *
  *   12/19/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void Play_Movie(char const * name, ThemeType theme, bool clrscrn_after, bool stretch, bool clrscrn_before)
+void Play_Movie(char const * name, ThemeType theme, bool clrscrn_after, bool stretch,
+	bool clrscrn_before, MixFileSearchFilter const * filter)
 {
 	if (!CCFileClass(name).Is_Available()) {
 		return;
@@ -89,7 +92,8 @@ void Play_Movie(char const * name, ThemeType theme, bool clrscrn_after, bool str
 
 	Keyboard->Clear();
 
-	VQHandle * vqa = Movie_Create(name, HiddenSurface, Rect(0,0,0,0), Rect(0,0,0,0), int(Options.SoundVolume * 255.0), 1);
+	VQHandle * vqa = Movie_Create(name, HiddenSurface, Rect(0,0,0,0), Rect(0,0,0,0),
+		int(Options.SoundVolume * 255.0), 1, filter);
 
 	if (vqa != NULL) {
 
@@ -164,6 +168,45 @@ void _Play_Movie(char const * name, ThemeType theme)
 			delete vqa;
 			Keyboard->Clear();
 		}
+	}
+}
+
+
+static bool Campaign_Intro_Archive(MixFileClass const * mixfile, void const * context)
+{
+	MixFileClass const * wanted = (MixFileClass const *)context;
+
+	if (mixfile == MoviesMix) {
+		return(mixfile == wanted);
+	}
+	for (int index = 0; index < MoviesMixLocal.Count(); index++) {
+		if (mixfile == MoviesMixLocal[index]) {
+			return(mixfile == wanted);
+		}
+	}
+	return(true);
+}
+
+
+/// <summary>
+/// Plays the opening film of a campaign.
+/// </summary>
+/// <param name="disc">The disc the campaign's files are on, as its CD number.</param>
+/// <remarks>Both base-game movie archives contain INTRO.VQA. Normal overrides retain their
+/// priority, but only the movie archive selected by the campaign is searched. If that archive
+/// is not mounted, the ordinary search order is used.</remarks>
+void Play_Campaign_Intro(int disc)
+{
+	char filename[64];
+
+	sprintf(filename, "MOVIES%02d.MIX", disc + 1);
+
+	MixFileClass * wanted = MFCD::Finder(filename);
+	if (wanted != NULL) {
+		MixFileSearchFilter const filter = {Campaign_Intro_Archive, wanted};
+		Play_Movie("INTRO.VQA", THEME_NONE, true, true, true, &filter);
+	} else {
+		Play_Movie("INTRO.VQA", THEME_NONE, true);
 	}
 }
 

--- a/code/movie.h
+++ b/code/movie.h
@@ -17,11 +17,14 @@
 #include "vq.hh"
 
 template<class T> class DynamicVectorClass;
+struct MixFileSearchFilter;
 
 extern DynamicVectorClass<char const *> Movies;
 
-void Play_Movie(char const * name, ThemeType theme=THEME_NONE, bool clrscrn_after=true, bool stretch=true, bool clrscrn_before=true);
+void Play_Movie(char const * name, ThemeType theme=THEME_NONE, bool clrscrn_after=true,
+	bool stretch=true, bool clrscrn_before=true, MixFileSearchFilter const * filter=NULL);
 void Play_Movie(VQType vq, ThemeType theme=THEME_NONE, bool clrscrn=true, bool stretch=true);
+void Play_Campaign_Intro(int disc);
 void Play_Ingame_Movie(VQType vq);
 void Pause_Ingame_Movie(bool pause);
 void Stop_Ingame_Movie(void);

--- a/code/movies.cpp
+++ b/code/movies.cpp
@@ -104,9 +104,11 @@ void Movie_Blit_To_Screen(void)
 /// <param name="volume">Volume to play the movie's sound track at.</param>
 /// <param name="fullscreen">Should each finished frame go straight to the screen rather than
 /// wait for the normal screen update?</param>
+/// <param name="filter">Optional archive filter used when the movie is opened from a mixfile.</param>
 /// <returns>Returns with a pointer to the movie created. Otherwise, NULL is returned if the
 /// file is missing or the movie could not be opened.</returns>
-VQHandle * Movie_Create(char const * name, Surface * surface, Rect rect1, Rect rect2, int volume, bool fullscreen)
+VQHandle * Movie_Create(char const * name, Surface * surface, Rect rect1, Rect rect2, int volume,
+	bool fullscreen, MixFileSearchFilter const * filter)
 {
 	VQA_SURF_DRAW_CALLBACK callback = NULL;
 	VQHandle *handle = new VQHandle;
@@ -132,7 +134,8 @@ VQHandle * Movie_Create(char const * name, Surface * surface, Rect rect1, Rect r
 			callback = Movie_Blit_To_Screen;
 		}
 
-		handle->VQA = new VQAClass(name, flags, Movie_Lock_Surface, Movie_Unlock_Surface, callback);
+		handle->VQA = new VQAClass(name, flags, Movie_Lock_Surface, Movie_Unlock_Surface, callback,
+			-1, -1, filter);
 		if (handle->VQA == NULL) {
 			delete handle;
 			return(NULL);

--- a/code/movies.h
+++ b/code/movies.h
@@ -15,13 +15,15 @@
 
 class VQAClass;
 class Surface;
+struct MixFileSearchFilter;
 struct VQHandle;
 template<class T> class DynamicVectorClass;
 
 void * Movie_Lock_Surface(void);
 bool Movie_Unlock_Surface(void);
 void Movie_Blit_To_Screen(void);
-VQHandle * Movie_Create(char const * name, Surface * surface, Rect rect1, Rect rect2, int volume, bool fullscreen);
+VQHandle * Movie_Create(char const * name, Surface * surface, Rect rect1, Rect rect2, int volume,
+	bool fullscreen, MixFileSearchFilter const * filter = NULL);
 void Movie_Destroy(VQHandle * handle);
 void Movie_Play(VQHandle *movie, bool hide_mouse, ThemeType theme, bool user_break_not_allowed);
 bool Movie_Advance_Frame(VQHandle * handle, bool &finished);

--- a/code/scenario.cpp
+++ b/code/scenario.cpp
@@ -342,7 +342,7 @@ bool Start_Scenario(char const * name, bool briefing, CampaignType campaign)
 	Theme.Stop();
 
 	if ((briefing == true) && (campaign != CAMPAIGN_NONE) && (Scen->Scenario == 1) && (Campaigns[Scen->Campaign]->CDNumber < 2)) {
-		Play_Movie("INTRO.VQA", THEME_NONE, true);
+		Play_Campaign_Intro(Campaigns[Scen->Campaign]->CDNumber);
 	}
 
 	DebugString("Reading scenario: %s\n", name);

--- a/code/vqa.cpp
+++ b/code/vqa.cpp
@@ -76,7 +76,9 @@ bool VQA_Message_Handler(void)
  *                                                                         *
  * HISTORY: See PVCS log                                                   *
  *=========================================================================*/
-VQAClass::VQAClass(char const * filename, int flags, VQA_SURF_LOCK_CALLBACK surface_lock, VQA_SURF_UNLOCK_CALLBACK surface_unlock, VQA_SURF_DRAW_CALLBACK surface_draw, int frame_rate, int draw_rate)
+VQAClass::VQAClass(char const * filename, int flags, VQA_SURF_LOCK_CALLBACK surface_lock,
+	VQA_SURF_UNLOCK_CALLBACK surface_unlock, VQA_SURF_DRAW_CALLBACK surface_draw,
+	int frame_rate, int draw_rate, MixFileSearchFilter const * filter)
 {
 	unsigned char buffer;
 
@@ -207,6 +209,7 @@ VQAClass::VQAClass(char const * filename, int flags, VQA_SURF_LOCK_CALLBACK surf
 	SurfaceLockCallback = surface_lock;
 	SurfaceUnlockCallback = surface_unlock;
 	SurfaceDrawCallback = surface_draw;
+	MixFilter = filter != NULL ? *filter : MixFileSearchFilter{NULL, NULL};
 	IsFileOpen = false;
 
 	// Initially, vqa is not open.
@@ -937,7 +940,7 @@ long VQAClass::MixFileHandler(long action, void * buffer, long nbytes)
 		case VQACMD_OPEN: {
 			int offset = 0;
 			MixFileClass * mixfile = NULL;
-			if (MixFileClass::Offset(Filename, NULL, &mixfile, &offset)) {
+			if (MixFileClass::Offset(Filename, NULL, &mixfile, &offset, NULL, &MixFilter)) {
 				IsFileOpen = FileHandle.Open(mixfile->Filename, FileClass::READ) != 0;
 				error = FileHandle.Seek(offset, SEEK_CUR) == 0;
 			} else {

--- a/code/vqa.h
+++ b/code/vqa.h
@@ -18,6 +18,7 @@
 //==========================================================================
 
 #include "ccfile.h"
+#include "mixfile.h"
 
 #include <vqaplay.h>
 
@@ -112,12 +113,15 @@ class VQAClass
 		VQA_SURF_LOCK_CALLBACK SurfaceLockCallback;
 		VQA_SURF_UNLOCK_CALLBACK SurfaceUnlockCallback;
 		VQA_SURF_DRAW_CALLBACK SurfaceDrawCallback;
+		MixFileSearchFilter MixFilter;
 		int Event3Frame;
 		bool IsPaused;
 		bool IsAdvanceReady;
 
 	public:
-		VQAClass(char const * filename, int flags, VQA_SURF_LOCK_CALLBACK surface_lock, VQA_SURF_UNLOCK_CALLBACK surface_unlock, VQA_SURF_DRAW_CALLBACK surface_draw, int frame_rate = -1, int draw_rate = -1);
+		VQAClass(char const * filename, int flags, VQA_SURF_LOCK_CALLBACK surface_lock,
+			VQA_SURF_UNLOCK_CALLBACK surface_unlock, VQA_SURF_DRAW_CALLBACK surface_draw,
+			int frame_rate = -1, int draw_rate = -1, MixFileSearchFilter const * filter = NULL);
 		~VQAClass (void);
 
 		bool Open_And_Load_Buffers(void);

--- a/manual/content/formats/mix.md
+++ b/manual/content/formats/mix.md
@@ -11,6 +11,7 @@ source_files:
   - code/mixfile.cpp
   - code/ccfile.cpp
   - code/init.cpp
+  - code/movie.cpp
 ---
 
 Registered MIX archives expose their members through the ordinary file layer, so a member is opened by name exactly as a file on disk is. A loose file with the requested name takes precedence over a member in a loaded archive, which permits local override files. Archive members are read-only through this file layer; a file opened for writing is always a real file on disk.
@@ -24,6 +25,8 @@ Startup insists on a few of them: `CACHE.MIX`, and then `CONQUER.MIX`, `SOUNDS.M
 Names are matched without regard to case. Each archive carries an index of its members sorted by a checksum of the member name, and a lookup is a binary search over that index rather than a scan, so nothing depends on the order members were packed in.
 
 Mounting an archive that is not there registers nothing and reports nothing: the object is created, finds no file, and never joins the list of archives to search. A name that no archive holds is not recorded anywhere either — the request falls through to opening a real file of that name, and fails when there is none.
+
+A lookup can omit selected archives without changing the mounted archive list. Campaign opening cinematics use this to search only the movie archive selected by [`CD=`](/keys/cd/#scope-campaign) while retaining the priority of earlier override archives. If the selected movie archive is not mounted, the normal search order applies.
 
 ## Caching
 

--- a/manual/content/keys/cd--campaign.md
+++ b/manual/content/keys/cd--campaign.md
@@ -8,9 +8,11 @@ when_omitted:
   value: "-1"
 ---
 
-`0` names the GDI disc, `1` the Nod disc and `2` the Firestorm disc, while `-1` names no disc in particular. No disc is ever asked for, so the number survives only as the side the campaign is treated as belonging to.
+`0` names the GDI disc, `1` the Nod disc and `2` the Firestorm disc, while `-1` names no disc. The value selects the campaign side and identifies the disc that supplies its files; OpenTS does not prompt for that disc.
 
-Two decisions read it. The opening cinematic plays ahead of the first mission's briefing only while the value is below `2`. The loading screen picks its backdrop from a pair of GDI pictures for `0` and a pair of Nod pictures for `1`; anything above `1` falls back to searching the campaign's opening scenario file name for `GDI`, taking the GDI pair when it is found and the Nod pair when it is not.
+For values below `2`, OpenTS plays an opening cinematic before the first mission's briefing. It reads `INTRO.VQA` from `MOVIES<nn>.MIX`, counting from `01`, because the base-game discs carry different films under that name. Earlier override archives keep their priority, but the [other movie archives](/formats/mix/#mounting-and-search-order) are omitted from this lookup. If the selected archive is not mounted, the normal search order applies.
+
+The same value selects the loading-screen backdrop. `0` uses one of two GDI pictures and `1` uses one of two Nod pictures. For values above `1`, OpenTS searches the campaign's opening scenario filename for `GDI`; a match uses the GDI pictures and no match uses the Nod pictures.
 
 :::caution[A campaign that names no disc reads its backdrop name from outside the table]
 The backdrop table is indexed straight from the disc number, so `-1` lands two places in front of it. The offsets used at 640 by 480, and at 800 by 600 or larger, carry the index back inside the table, but at every other screen size the file name is taken from the bytes in front of it.


### PR DESCRIPTION
This fixes campaign intros so CD= selects the corresponding MOVIESnn.MIX when multiple movie archives are mounted. There's a request-scoped archive filter and it falls back to the normal search order when the selected archive is unavailable.

Fixes #95.