### PR TITLE
Report VQA errors through a typed enum

### DIFF
--- a/code/vqalib/audio.cpp
+++ b/code/vqalib/audio.cpp
@@ -110,10 +110,9 @@ static void StartAddr(void)
 *
 ****************************************************************************/
 
-long VQA_OpenAudio(VQAHandleP *vqap)
+VQAErrorType VQA_OpenAudio(VQAHandleP *vqap)
 {
 	VQAAudio *audio;
-	long          rc;
 
 	/* Dereference data memebers for quicker access. */
 	audio = &vqap->Audio;
@@ -134,8 +133,9 @@ long VQA_OpenAudio(VQAHandleP *vqap)
 	params.Callback1 = VQA_AudioFillCallback;
 	params.Callback2 = VQA_AudioDoneCallback;
 
-	rc = (long)vqap->Config.AudioHandler((VQAHandle *)vqap, VQAAUDIO_OPEN, &params, sizeof(params));
-	if (rc >= VQAERR_OK || rc == VQAERR_NONE) {
+	auto const opened = vqap->Config.AudioHandler((VQAHandle *)vqap, VQAAUDIO_OPEN, &params, sizeof(params));
+
+	if (opened >= VQAERR_OK || opened == VQAERR_NONE) {
 
 		/* Lock the memory occupied by this module. */
 		if ((audio->Flags & VQAAUDF_MODLOCKED) == 0) {
@@ -143,7 +143,7 @@ long VQA_OpenAudio(VQAHandleP *vqap)
 		}
 		return(VQAERR_NONE);
 	}
-	return(rc);
+	return((VQAErrorType)opened);
 }
 
 

--- a/code/vqalib/audio.cpp
+++ b/code/vqalib/audio.cpp
@@ -96,7 +96,7 @@ static void StartAddr(void)
 * SYNOPSIS
 *     Error = VQA_OpenAudio(VQAHandleP)
 *
-*     long VQA_OpenAudio(VQAHandleP *);
+*     VQAErrorType VQA_OpenAudio(VQAHandleP *);
 *
 * FUNCTION
 *     Initialise the sound system. Create a direct sound object and the

--- a/code/vqalib/buffer_.cpp
+++ b/code/vqalib/buffer_.cpp
@@ -17,7 +17,7 @@
 #include	<string.h>
 #include	"vqamem.h"
 
-extern long VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long width, unsigned long height, long xpos, long ypos);
+extern VQAErrorType VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long width, unsigned long height, long xpos, long ypos);
 
 
 _STATIC void VQA_BufferPerpareLoop(VQAHandleP *vqap, long * needs_start_cb, long * needs_end_cb);
@@ -58,7 +58,7 @@ _STATIC void VQA_BufferPerpareLoop(VQAHandleP *vqap, long * needs_start_cb, long
 *
 ****************************************************************************/
 
-STATIC long AllocBuffers(VQAHandleP *vqap)
+STATIC VQAErrorType AllocBuffers(VQAHandleP *vqap)
 {
 	long needs_start_cb;
 	long needs_end_cb;
@@ -706,7 +706,7 @@ STATIC void FreeBuffers(VQAHandleP *vqap)
 }
 
 
-long VQA_Configure_Buffer(VQAHandleP *vqap)
+VQAErrorType VQA_Configure_Buffer(VQAHandleP *vqap)
 {
 	unsigned char *buf;
 	int w;

--- a/code/vqalib/drawer.cpp
+++ b/code/vqalib/drawer.cpp
@@ -74,21 +74,21 @@
 #include    "../lcw.h"
 
 //forward declarations
-_STATIC long Select_Frame(VQAHandleP *vqap);
+_STATIC VQAErrorType Select_Frame(VQAHandleP *vqap);
 _STATIC void Prepare_Frame(VQAHandleP *vqap);
 
-long DrawFrame_MCGABuf(VQAHandle *vqa);
-long PageFlip_MCGABuf(VQAHandle *vqa);
-long DrawFrame_MCGA(VQAHandle *vqa);
-long PageFlip_MCGA(VQAHandle *vqa);
+VQAErrorType DrawFrame_MCGABuf(VQAHandle *vqa);
+VQAErrorType PageFlip_MCGABuf(VQAHandle *vqa);
+VQAErrorType DrawFrame_MCGA(VQAHandle *vqa);
+VQAErrorType PageFlip_MCGA(VQAHandle *vqa);
 
 void __cdecl UnVQ_Nop(uint8_t *codebook, uint8_t *pointers, uint8_t *buffer, size_t blocksperrow, size_t numrows, size_t bufwidth);
-long PageFlip_Nop(VQAHandle *vqa);
+VQAErrorType PageFlip_Nop(VQAHandle *vqa);
 
 void VQA_SetTimer(VQAHandleP *vqap, long time);
 void VQA_StepTimer(VQAHandleP *vqap, long step);
 unsigned long VQA_GetTime(VQAHandleP *vqap);
-_STATIC long VQA_SetCurrentFrameAsLast(VQAHandleP *vqap);
+_STATIC VQAErrorType VQA_SetCurrentFrameAsLast(VQAHandleP *vqap);
 _STATIC void VQA_SetPreviousFrameNode(VQAHandleP *vqap);
 _STATIC long VQA_CalcFramesSinceDrawn(VQAHandleP *vqap);
 
@@ -103,7 +103,7 @@ void VQA_DispatchFrameChunks(VQAHandleP *vqap, long frame);
 /// no frame has been drawn yet.
 /// </summary>
 /// <returns>Returns with VQAERR_NONE.</returns>
-long VQA_ResetLastFrameNum(VQAHandle *vqa)
+VQAErrorType VQA_ResetLastFrameNum(VQAHandle *vqa)
 {
 	VQAHandleP *vqap;
 	VQADrawer *drawer;
@@ -139,7 +139,7 @@ long VQA_ResetLastFrameNum(VQAHandle *vqa)
 *
 ****************************************************************************/
 
-long VQA_Configure_Drawer(VQAHandleP *vqap)
+VQAErrorType VQA_Configure_Drawer(VQAHandleP *vqap)
 {
 	VQAConfig *config;
 	VQAHeader *header;
@@ -266,7 +266,7 @@ long VQA_Configure_Drawer(VQAHandleP *vqap)
 *
 ****************************************************************************/
 
-STATIC long Select_Frame(VQAHandleP *vqap)
+STATIC VQAErrorType Select_Frame(VQAHandleP *vqap)
 {
 	VQADrawer    *drawer;
 	VQAConfig    *config;
@@ -669,7 +669,7 @@ long VQA_CalcFramesSinceDrawn(VQAHandleP *vqap)
 /// notion of playback progress once a frame has been committed.
 /// </summary>
 /// <returns>Returns with VQAERR_NONE.</returns>
-long VQA_SetCurrentFrameAsLast(VQAHandleP *vqap)
+VQAErrorType VQA_SetCurrentFrameAsLast(VQAHandleP *vqap)
 {
 	VQADrawer * drawer;
 
@@ -894,12 +894,12 @@ void VQA_UnVQFrame(VQAHandleP *vqap, VQAFrameNode *frame)
 *
 ****************************************************************************/
 
-long DrawFrame_MCGA(VQAHandle *vqa)
+VQAErrorType DrawFrame_MCGA(VQAHandle *vqa)
 {
 	VQAHandleP *vqap;
 	VQADrawer    *drawer;
 	VQAFrameNode *curframe;
-	long         rc;
+	VQAErrorType         rc;
 
 	/* Dereference commonly used data members for quicker access */
 	vqap = (VQAHandleP *)vqa;
@@ -953,7 +953,7 @@ long DrawFrame_MCGA(VQAHandle *vqa)
 *
 ****************************************************************************/
 
-STATIC long PageFlip_MCGA(VQAHandle *vqa)
+STATIC VQAErrorType PageFlip_MCGA(VQAHandle *vqa)
 {
 	VQAHandleP *vqap;
 	VQADrawer     *drawer;
@@ -1054,9 +1054,9 @@ STATIC long PageFlip_MCGA(VQAHandle *vqa)
 *
 ****************************************************************************/
 
-STATIC long DrawFrame_MCGABuf(VQAHandle *vqa)
+STATIC VQAErrorType DrawFrame_MCGABuf(VQAHandle *vqa)
 {
-	long rc;
+	VQAErrorType rc;
 	VQAHandleP *vqap;
 	VQADrawer *drawer;
 	VQAFrameNode *curframe;
@@ -1112,7 +1112,7 @@ STATIC long DrawFrame_MCGABuf(VQAHandle *vqa)
 *
 ****************************************************************************/
 
-STATIC long PageFlip_MCGABuf(VQAHandle *vqa)
+STATIC VQAErrorType PageFlip_MCGABuf(VQAHandle *vqa)
 {
 	VQAHandleP *vqap;
 	VQADrawer *drawer;
@@ -1238,7 +1238,7 @@ STATIC void __cdecl UnVQ_Nop(uint8_t *codebook, uint8_t *pointers,
 *
 ****************************************************************************/
 
-STATIC long PageFlip_Nop(VQAHandle *vqa)
+STATIC VQAErrorType PageFlip_Nop(VQAHandle *vqa)
 {
 	//shut up compiler warnings
 	vqa = vqa;

--- a/code/vqalib/drawer.cpp
+++ b/code/vqalib/drawer.cpp
@@ -252,7 +252,7 @@ VQAErrorType VQA_Configure_Drawer(VQAHandleP *vqap)
 * SYNOPSIS
 *     Error = Select_Frame(VQA)
 *
-*     long Select_Frame(VQAHandleP *);
+*     VQAErrorType Select_Frame(VQAHandleP *);
 *
 * FUNCTION
 *     Select a frame to draw. This is were the frame skipping/delay is
@@ -864,7 +864,7 @@ void VQA_UnVQFrame(VQAHandleP *vqap, VQAFrameNode *frame)
 * SYNOPSIS
 *     Error = DrawFrame_MCGA(VQA)
 *
-*     long DrawFrame_MCGA(VQAHandle *);
+*     VQAErrorType DrawFrame_MCGA(VQAHandle *);
 *
 * FUNCTION
 *     Algorithm:
@@ -939,7 +939,7 @@ VQAErrorType DrawFrame_MCGA(VQAHandle *vqa)
 * SYNOPSIS
 *     PageFlip_MCGA(VQA)
 *
-*     long PageFlip_MCGA(VQAHandle *);
+*     VQAErrorType PageFlip_MCGA(VQAHandle *);
 *
 * FUNCTION
 *     Since the MCGA mode only has one buffer, the drawing is actually done
@@ -1022,7 +1022,7 @@ STATIC VQAErrorType PageFlip_MCGA(VQAHandle *vqa)
 * SYNOPSIS
 *     Error = DrawFrame_MCGABuf(VQA)
 *
-*     long DrawFrame_MCGABuf(VQAHandle *);
+*     VQAErrorType DrawFrame_MCGABuf(VQAHandle *);
 *
 * FUNCTION
 *     Algorithm:

--- a/code/vqalib/loader.cpp
+++ b/code/vqalib/loader.cpp
@@ -146,7 +146,7 @@ VQAErrorType VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQAB
 * SYNOPSIS
 *     Error = VQA_LoadFrame(VQA)
 *
-*     long VQA_LoadFrame(VQAHandle *);
+*     VQAErrorType VQA_LoadFrame(VQAHandle *);
 *
 * FUNCTION
 *     The codebook is split up such that the last frame of every group gets
@@ -1593,7 +1593,7 @@ _STATIC VQAErrorType VQA_LoadLoop(VQAHandleP *vqap, long framenum)
 * SYNOPSIS
 *     Error = Load_VQF(VQA, Iffsize)
 *
-*     long Load_VQF(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_VQF(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *     The VQ Frame Chunk contains a set of other chunks (codebooks,
@@ -2561,7 +2561,7 @@ VQAErrorType Load_PIND(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_FINF(VQA, Iffsize)
 *
-*     long Load_FINF(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_FINF(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *     Load FINF chunk if buffer available, otherwise skip it.
@@ -2607,7 +2607,7 @@ VQAErrorType Load_FINF(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_VQHD(VQA, Iffsize)
 *
-*     long Load_VQHD(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_VQHD(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -2645,7 +2645,7 @@ static VQAErrorType Load_VQHD(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_CBF0(VQA, Iffsize)
 *
-*     long Load_CBF0(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_CBF0(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -2701,7 +2701,7 @@ VQAErrorType Load_CBF0(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_CBFZ(VQA, Iffsize)
 *
-*     long Load_CBFZ(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_CBFZ(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -2764,7 +2764,7 @@ VQAErrorType Load_CBFZ(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_CBP0(VQA, Iffsize)
 *
-*     long Load_CBP0(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_CBP0(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -2858,7 +2858,7 @@ VQAErrorType Load_CBP0(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_CBPZ(VQA, Iffsize)
 *
-*     long Load_CBPZ(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_CBPZ(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -2972,7 +2972,7 @@ VQAErrorType Load_CBPZ(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_CPL0(VQA, Iffsize)
 *
-*     long Load_CPL0(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_CPL0(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -3024,7 +3024,7 @@ VQAErrorType Load_CPL0(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_CPLZ(VQA, Iffsize)
 *
-*     long Load_CPLZ(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_CPLZ(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -3087,7 +3087,7 @@ VQAErrorType Load_CPLZ(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_VPT0(VQA, Iffsize)
 *
-*     long Load_VPT0(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_VPT0(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -3130,7 +3130,7 @@ VQAErrorType Load_VPT0(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_VPTZ(VQA, Iffsize)
 *
-*     long Load_VPTZ(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_VPTZ(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *
@@ -3183,7 +3183,7 @@ VQAErrorType Load_VPTZ(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_SND0(VQA, Iffsize)
 *
-*     long Load_SND0(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_SND0(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *     This routine normally loads the chunk into the TempBuf, unless the
@@ -3272,7 +3272,7 @@ VQAErrorType Load_SND0(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_SND1(VQA, Iffsize)
 *
-*     long Load_SND1(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_SND1(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *     This routine normally loads the chunk into the TempBuf, unless the
@@ -3413,7 +3413,7 @@ VQAErrorType Load_SND1(VQAHandleP *vqap, unsigned long iffsize)
 * SYNOPSIS
 *     Error = Load_SND2(VQA, Iffsize)
 *
-*     long Load_SND2(VQAHandleP *, unsigned long);
+*     VQAErrorType Load_SND2(VQAHandleP *, unsigned long);
 *
 * FUNCTION
 *     This routine normally loads the chunk into the TempBuf, unless the

--- a/code/vqalib/loader.cpp
+++ b/code/vqalib/loader.cpp
@@ -73,69 +73,69 @@
  * PRIVATE DECLARATIONS
  *-------------------------------------------------------------------------*/
 
-long Load_FINF(VQAHandleP *vqap, unsigned long iffsize);
-long Load_CINF(VQAHandleP *vqap);
-long Load_PINF(VQAHandleP *vqap);
-long Load_LINF(VQAHandleP *vqap);
-long Load_CLIP(VQAHandleP *vqap, unsigned long iffsize);
-long Load_MFCI(VQAHandleP *vqap);
+VQAErrorType Load_FINF(VQAHandleP *vqap, unsigned long iffsize);
+VQAErrorType Load_CINF(VQAHandleP *vqap);
+VQAErrorType Load_PINF(VQAHandleP *vqap);
+VQAErrorType Load_LINF(VQAHandleP *vqap);
+VQAErrorType Load_CLIP(VQAHandleP *vqap, unsigned long iffsize);
+VQAErrorType Load_MFCI(VQAHandleP *vqap);
 
-long Load_MSCI(VQAHandleP *vqap);
+VQAErrorType Load_MSCI(VQAHandleP *vqap);
 
-_STATIC long Load_VQF(VQAHandleP *vqap, unsigned long frame_iffsize, char flags);
-_STATIC long Load_CBF0(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CBFZ(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CBP0(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CBPZ(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CPL0(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CPLZ(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_VPT0(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_VPTZ(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_VQF(VQAHandleP *vqap, unsigned long frame_iffsize, char flags);
+_STATIC VQAErrorType Load_CBF0(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CBFZ(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CBP0(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CBPZ(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CPL0(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CPLZ(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_VPT0(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_VPTZ(VQAHandleP *vqap, unsigned long iffsize);
 
 #if(VQAAUDIO_ON)
-_STATIC long Load_SND0(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_SND1(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_SND2(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_SN2J(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_SND0(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_SND1(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_SND2(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_SN2J(VQAHandleP *vqap, unsigned long iffsize);
 #endif
 
-_STATIC long Load_LINH(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_LIND(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CINH(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_CIND(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_PINH(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_PIND(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_LINH(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_LIND(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CINH(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_CIND(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_PINH(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_PIND(VQAHandleP *vqap, unsigned long iffsize);
 
-_STATIC long Load_MSCH(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_MSCT(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_MSCH(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_MSCT(VQAHandleP *vqap, unsigned long iffsize);
 
-_STATIC long Load_MFCH(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_MFCD(VQAHandleP *vqap, unsigned long iffsize);
-_STATIC long Load_MFCT(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_MFCH(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_MFCD(VQAHandleP *vqap, unsigned long iffsize);
+_STATIC VQAErrorType Load_MFCT(VQAHandleP *vqap, unsigned long iffsize);
 
 _STATIC long VQA_GetCodebookSize(VQAHandleP *vqap, long framenum);
-_STATIC long VQA_MFCIPrepare(VQAHandleP *vqap, unsigned long index);
+_STATIC VQAErrorType VQA_MFCIPrepare(VQAHandleP *vqap, unsigned long index);
 _STATIC long VQA_MFCICalcCount(VQAHandleP *vqap, unsigned long chunkid, long count, unsigned long value);
 _STATIC VQABool VQA_MFCISpansLoop(VQAHandleP *vqap, unsigned long chunkid, unsigned long value);
 
-_STATIC long VQA_MSCIPrepare(VQAHandleP *vqap, unsigned long index);
-_STATIC long VQA_MSCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index);
+_STATIC VQAErrorType VQA_MSCIPrepare(VQAHandleP *vqap, unsigned long index);
+_STATIC VQAErrorType VQA_MSCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index);
 
 _STATIC long VQA_MFCIIndexFromChunkID(VQAHandleP *vqap, unsigned long chunkid);
-_STATIC long VQA_MFCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index);
+_STATIC VQAErrorType VQA_MFCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index);
 _STATIC long VQA_MSCIIndexFromChunkID(VQAHandleP *vqap, unsigned long chunkid);
 
 _STATIC long VQA_GetPaletteFrameRange(VQAHandleP *vqap, long framenum, long * first_frame, long * last_frame);
-_STATIC long VQA_SeekLoop(VQAHandleP *vqap, long framenum, long flags);
+_STATIC VQAErrorType VQA_SeekLoop(VQAHandleP *vqap, long framenum, long flags);
 _STATIC long VQA_GetCodebookFrameRange(VQAHandleP *vqap, long framenum, long *first_frame, long *last_frame);
 VQABool VQA_IsFrameStartOfLoop(VQAHandleP *vqap, long framenum);
-long VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force);
-_STATIC long VQA_LoadLoop(VQAHandleP *vqap, long framenum);
+VQAErrorType VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force);
+_STATIC VQAErrorType VQA_LoadLoop(VQAHandleP *vqap, long framenum);
 
 intptr_t __cdecl Memory_VQA_Stream_Handler(VQAHandle *vqa, long action, void *buffer, long nbytes);
-_STATIC long VQA_LoadFrame_Internal(VQAHandleP *vqap, long flags);
+_STATIC VQAErrorType VQA_LoadFrame_Internal(VQAHandleP *vqap, long flags);
 
-long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool preloadaudio, VQABool reset_state, VQABool &skipcodebook);
+VQAErrorType VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool preloadaudio, VQABool reset_state, VQABool &skipcodebook);
 
 
 /****************************************************************************
@@ -175,7 +175,7 @@ long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool prel
 *     Error - 0 if successful or VQAERR_??? error code.
 *
 ****************************************************************************/
-long VQA_LoadFrame(VQAHandleP *vqap, long flags)
+VQAErrorType VQA_LoadFrame(VQAHandleP *vqap, long flags)
 {
 	VQAConfig *config;
 	VQALoader *loader;
@@ -186,7 +186,7 @@ long VQA_LoadFrame(VQAHandleP *vqap, long flags)
 	int scan_frame;
 	int tocache;
 	VQA_H_FUNC handler;
-	unsigned int rc;
+	VQAErrorType rc;
 	int val4;
 	int fsize;
 	VQA_H_FUNC oldhandler;
@@ -263,7 +263,7 @@ long VQA_LoadFrame(VQAHandleP *vqap, long flags)
 						config->StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, NULL, foffset);
 					}
 					if (config->StreamHandler((VQAHandle *)vqap, VQACMD_READ, &cache->Ptr[cache->Offset], tocache)) {
-						return -4;
+						return(VQAERR_READ);
 					}
 					cache->Bytes += tocache;
 				}
@@ -309,7 +309,7 @@ struct VQASN2J {
 #pragma pack(pop)
 
 
-long VQA_LoadFrame_Internal(VQAHandleP *vqap, long flags)
+VQAErrorType VQA_LoadFrame_Internal(VQAHandleP *vqap, long flags)
 {
 	VQAConfig     *config;
 	VQALoader     *loader;
@@ -322,7 +322,7 @@ long VQA_LoadFrame_Internal(VQAHandleP *vqap, long flags)
 	VQABool      loop_loaded = 0;
 
 
-	long          rc;
+	VQAErrorType          rc;
 
 	/* Dereference commonly used data members for quicker access. */
 	config = &vqap->Config;
@@ -871,11 +871,11 @@ long VQA_LoadFrame_Internal(VQAHandleP *vqap, long flags)
 }
 
 
-long PrimeBuffers(VQAHandle *vqa)
+VQAErrorType PrimeBuffers(VQAHandle *vqa)
 {
 	VQAHandleP *vqap;
 	VQAConfig *config;
-	long rc;
+	VQAErrorType rc;
 	long i;
 
 	vqap = ((VQAHandleP *)vqa);
@@ -920,7 +920,7 @@ long VQA_MFCIIndexFromChunkID(VQAHandleP *vqap, unsigned long chunkid)
 /// <param name="iffsize">Size of IFF chunk.</param>
 /// <param name="index">Index of the multi-frame chunk table entry to read into.</param>
 /// <returns>Returns with VQAERR_NONE if successful, or a VQAERR_??? error code.</returns>
-long VQA_MFCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index)
+VQAErrorType VQA_MFCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index)
 {
 	void *buf;
 	VQALoader *loader;
@@ -987,7 +987,7 @@ long VQA_MSCIIndexFromChunkID(VQAHandleP *vqap, unsigned long chunkid)
 /// <param name="iffsize">Size of IFF chunk.</param>
 /// <param name="index">Index of the multi-stream chunk table entry to read into.</param>
 /// <returns>Returns with VQAERR_NONE if successful, or a VQAERR_??? error code.</returns>
-long VQA_MSCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index)
+VQAErrorType VQA_MSCIReadData(VQAHandleP *vqap, unsigned long iffsize, long index)
 {
 	VQAConfig *config;
 	VQALoader *loader;
@@ -1058,9 +1058,9 @@ VQABool VQA_IsFrameStartOfLoop(VQAHandleP *vqap, long framenum)
 }
 
 
-long VQA_SeekLoop(VQAHandleP *vqap, long framenum, long flags)
+VQAErrorType VQA_SeekLoop(VQAHandleP *vqap, long framenum, long flags)
 {
-	long rc = VQAERR_NONE;
+	VQAErrorType rc = VQAERR_NONE;
 	VQAConfig *config;
 	VQALoopCache *cache;
 	bool needs_seek = false;
@@ -1154,13 +1154,13 @@ long VQA_GetPaletteFrameRange(VQAHandleP *vqap, long framenum, long * first_fram
 /// </summary>
 /// <param name="framenum">The frame whose palette is required.</param>
 /// <param name="force">Non-zero to force a full reload rather than reloading only when the palette has changed.</param>
-long VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force)
+VQAErrorType VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force)
 {
 	VQALoader *loader;
 	VQAFrameNode *curframe;
 	VQAConfig *config;
 
-	long rc = -1;
+	VQAErrorType rc = VQAERR_NONE;
 
 	loader = &vqap->Loader;
 	curframe = loader->CurFrame;
@@ -1247,7 +1247,7 @@ long VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force)
 /// <param name="reset_state">Should the loader and audio state be reset before seeking?</param>
 /// <param name="skipcodebook">Set true if the full codebook is already valid, so that the caller may skip codebook assembly.</param>
 /// <returns>Returns with VQAERR_NONE if successful, or a VQAERR_??? error code.</returns>
-long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool preloadaudio, VQABool reset_state, VQABool &skipcodebook)
+VQAErrorType VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool preloadaudio, VQABool reset_state, VQABool &skipcodebook)
 {
 	//VQAHandleP   *vqap;
 	VQALoader    *loader;
@@ -1267,7 +1267,7 @@ long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool prel
 	int bytes_per_frame;
 	int preload_frames;
 	int covered_bytes;
-	unsigned int rc;
+	VQAErrorType rc;
 	bool bool2;
 	int loadflags;
 	long group_end;
@@ -1452,7 +1452,7 @@ long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool prel
 			if ( reset_state )
 			{
 				if (rc == VQAERR_NOBUFFER || rc == VQAERR_SLEEPING) {
-					rc = -1;
+					rc = VQAERR_NONE;
 				}
 			}
 
@@ -1464,7 +1464,7 @@ long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool prel
 		 */
 		if (!config->StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, (void *)SEEK_SET, VQAFRAME_OFFSET(vqap->Foff[group]))) {
 			loader->CurFrameNum = group;
-			rc = -1;
+			rc = VQAERR_NONE;
 
 			loadflags = (VQALOADF_NOPAL|VQALOADF_NOPTR);
 			if (group_index) {
@@ -1536,14 +1536,14 @@ long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool prel
 /// </summary>
 /// <param name="framenum">The loop start frame to rewind to.</param>
 /// <returns>Returns with VQAERR_NONE if successful, or a VQAERR_??? error code.</returns>
-_STATIC long VQA_LoadLoop(VQAHandleP *vqap, long framenum)
+_STATIC VQAErrorType VQA_LoadLoop(VQAHandleP *vqap, long framenum)
 {
 	VQALoader *loader;
 	VQAHeader *header;
 	VQAConfig *config;
 
 
-	long rc = VQAERR_NONE;
+	VQAErrorType rc = VQAERR_NONE;
 	VQABool skipcodebook = false;
 
 	loader = &vqap->Loader;
@@ -1609,7 +1609,7 @@ _STATIC long VQA_LoadLoop(VQAHandleP *vqap, long framenum)
 *
 ****************************************************************************/
 
-long Load_VQF(VQAHandleP *vqap, unsigned long frame_iffsize, char flags)
+VQAErrorType Load_VQF(VQAHandleP *vqap, unsigned long frame_iffsize, char flags)
 {
 	VQAFrameNode  *curframe;
 	ChunkHeader   *chunk;
@@ -1836,7 +1836,7 @@ long Load_VQF(VQAHandleP *vqap, unsigned long frame_iffsize, char flags)
 }
 
 
-long Load_CLIP(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CLIP(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->Clipper, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -1845,7 +1845,7 @@ long Load_CLIP(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_LINF(VQAHandleP *vqap)
+VQAErrorType Load_LINF(VQAHandleP *vqap)
 {
 	unsigned long iffsize;
 	ChunkHeader chunk;
@@ -1895,7 +1895,7 @@ long Load_LINF(VQAHandleP *vqap)
 }
 
 
-long Load_LINH(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_LINH(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->LoopInfo.Header, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -1904,7 +1904,7 @@ long Load_LINH(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_LIND(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_LIND(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, vqap->LoopInfo.Data, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -1913,7 +1913,7 @@ long Load_LIND(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_MFCI(VQAHandleP *vqap)
+VQAErrorType Load_MFCI(VQAHandleP *vqap)
 {
 	ChunkHeader chunk;
 	VQAConfig *config;
@@ -2000,7 +2000,7 @@ long Load_MFCI(VQAHandleP *vqap)
 		vqap->MemUsed += size;
 
 		for (unsigned long i = 0; i < count; i++) {
-			long rc = VQA_MFCIPrepare(vqap, i);
+			VQAErrorType rc = VQA_MFCIPrepare(vqap, i);
 			if (rc != VQAERR_NONE) {
 				return(rc);
 			}
@@ -2011,7 +2011,7 @@ long Load_MFCI(VQAHandleP *vqap)
 }
 
 
-long Load_MFCH(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_MFCH(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->MFCInfo.Header, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2020,7 +2020,7 @@ long Load_MFCH(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_MFCD(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_MFCD(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, vqap->MFCInfo.StaticData, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2029,7 +2029,7 @@ long Load_MFCD(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_MFCT(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_MFCT(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, vqap->MFCInfo.Table, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2038,7 +2038,7 @@ long Load_MFCT(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_MSCI(VQAHandleP *vqap)
+VQAErrorType Load_MSCI(VQAHandleP *vqap)
 {
 	ChunkHeader chunk;
 	VQAConfig *config;
@@ -2101,7 +2101,7 @@ long Load_MSCI(VQAHandleP *vqap)
 		vqap->MemUsed += size;
 
 		for (unsigned long i = 0; i < count; i++) {
-			long rc = VQA_MSCIPrepare(vqap, i);
+			VQAErrorType rc = VQA_MSCIPrepare(vqap, i);
 			if (rc != VQAERR_NONE) {
 				return(rc);
 			}
@@ -2112,7 +2112,7 @@ long Load_MSCI(VQAHandleP *vqap)
 }
 
 
-long Load_MSCH(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_MSCH(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->MSCInfo.Header, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2121,7 +2121,7 @@ long Load_MSCH(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_MSCT(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_MSCT(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, vqap->MSCInfo.Table, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2218,7 +2218,7 @@ long VQA_MFCICalcCount(VQAHandleP *vqap, unsigned long chunkid, long count, unsi
 /// </summary>
 /// <param name="index">Index of the multi-frame chunk table entry to prepare.</param>
 /// <returns>Returns with VQAERR_NONE if successful, or VQAERR_NOMEM if a buffer could not be allocated.</returns>
-long VQA_MFCIPrepare(VQAHandleP *vqap, unsigned long index)
+VQAErrorType VQA_MFCIPrepare(VQAHandleP *vqap, unsigned long index)
 {
 	VQAConfig *config;
 	unsigned long size;
@@ -2278,7 +2278,7 @@ long VQA_MFCIPrepare(VQAHandleP *vqap, unsigned long index)
 /// </summary>
 /// <param name="index">Index of the multi-stream chunk table entry to prepare.</param>
 /// <returns>Returns with VQAERR_NONE if successful, or VQAERR_NOMEM if a buffer could not be allocated.</returns>
-long VQA_MSCIPrepare(VQAHandleP *vqap, unsigned long index)
+VQAErrorType VQA_MSCIPrepare(VQAHandleP *vqap, unsigned long index)
 {
 	VQAConfig *config;
 	unsigned long size;
@@ -2413,7 +2413,7 @@ long VQA_GetCodebookFrameRange(VQAHandleP *vqap, long framenum, long *first_fram
 }
 
 
-long Load_CINF(VQAHandleP *vqap)
+VQAErrorType Load_CINF(VQAHandleP *vqap)
 {
 	int groupsize;
 	long size;
@@ -2467,7 +2467,7 @@ long Load_CINF(VQAHandleP *vqap)
 }
 
 
-long Load_CINH(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CINH(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->CodebookInfo.Header, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2476,7 +2476,7 @@ long Load_CINH(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_CIND(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CIND(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, vqap->CodebookInfo.Data, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2485,7 +2485,7 @@ long Load_CIND(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_PINF(VQAHandleP *vqap)
+VQAErrorType Load_PINF(VQAHandleP *vqap)
 {
 	unsigned long iffsize;
 	ChunkHeader chunk;
@@ -2535,7 +2535,7 @@ long Load_PINF(VQAHandleP *vqap)
 }
 
 
-long Load_PINH(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_PINH(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->PaletteInfo.Header, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2544,7 +2544,7 @@ long Load_PINH(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_PIND(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_PIND(VQAHandleP *vqap, unsigned long iffsize)
 {
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, vqap->PaletteInfo.Data, PADSIZE(iffsize))) {
 		return(VQAERR_READ);
@@ -2575,7 +2575,7 @@ long Load_PIND(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_FINF(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_FINF(VQAHandleP *vqap, unsigned long iffsize)
 {
 	/* Dereference commonly used data members for quicker access. */
 	/* Load the frame information table if we need to, otherwise we will
@@ -2620,7 +2620,7 @@ long Load_FINF(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-static long Load_VQHD(VQAHandleP *vqap, unsigned long iffsize)
+static VQAErrorType Load_VQHD(VQAHandleP *vqap, unsigned long iffsize)
 {
 	/* Read the header */
 	if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_READ, &vqap->Header,
@@ -2658,7 +2658,7 @@ static long Load_VQHD(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_CBF0(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CBF0(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQALoader *loader;
 	VQACBNode *curcb;
@@ -2714,7 +2714,7 @@ long Load_CBF0(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_CBFZ(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CBFZ(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQALoader     *loader;
 	VQACBNode     *curcb;
@@ -2777,7 +2777,7 @@ long Load_CBFZ(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_CBP0(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CBP0(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQALoader *loader;
 	VQACBNode *curcb;
@@ -2871,7 +2871,7 @@ long Load_CBP0(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_CBPZ(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CBPZ(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQAConfig     *config;
 	VQALoader     *loader;
@@ -2985,7 +2985,7 @@ long Load_CBPZ(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_CPL0(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CPL0(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQADrawer *drawer;
 	VQAFrameNode *curframe;
@@ -3037,7 +3037,7 @@ long Load_CPL0(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_CPLZ(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_CPLZ(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQADrawer *drawer;
 	VQAFrameNode  *curframe;
@@ -3100,7 +3100,7 @@ long Load_CPLZ(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_VPT0(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_VPT0(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQAFrameNode *curframe;
 
@@ -3143,7 +3143,7 @@ long Load_VPT0(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_VPTZ(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_VPTZ(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQAFrameNode  *curframe;
 	void          *buffer;
@@ -3200,7 +3200,7 @@ long Load_VPTZ(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_SND0(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_SND0(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQAAudio      *audio;
 	VQAConfig     *config;
@@ -3299,7 +3299,7 @@ static void Unzap_Frame(unsigned char const *loadbuf, unsigned long padsize, uns
 }
 
 
-long Load_SND1(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_SND1(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQAAudio      *audio;
 	VQAConfig     *config;
@@ -3430,7 +3430,7 @@ long Load_SND1(VQAHandleP *vqap, unsigned long iffsize)
 *
 ****************************************************************************/
 
-long Load_SND2(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_SND2(VQAHandleP *vqap, unsigned long iffsize)
 {
 	VQAAudio      *audio;
 	VQAConfig     *config;
@@ -3511,7 +3511,7 @@ long Load_SND2(VQAHandleP *vqap, unsigned long iffsize)
 }
 
 
-long Load_SN2J(VQAHandleP *vqap, unsigned long iffsize)
+VQAErrorType Load_SN2J(VQAHandleP *vqap, unsigned long iffsize)
 {
 	unsigned long padsize;
 	VQAConfig     *config;

--- a/code/vqalib/task.cpp
+++ b/code/vqalib/task.cpp
@@ -116,7 +116,7 @@ extern void __cdecl UnVQ_Nop(uint8_t *codebook, uint8_t *pointers,
 * SYNOPSIS
 *     Error = VQA_Open(VQA, Name, Config)
 *
-*     long VQA_Open(VQAHandle *, char *, VQAConfig *);
+*     VQAErrorType VQA_Open(VQAHandle *, char *, VQAConfig *);
 *
 * FUNCTION
 *     - Open a VQA file for reading.

--- a/code/vqalib/task.cpp
+++ b/code/vqalib/task.cpp
@@ -63,41 +63,41 @@
 #include "vqadebug.h"
 
 
-long VQA_ResetLastFrameNum(VQAHandle *vqa);
+VQAErrorType VQA_ResetLastFrameNum(VQAHandle *vqa);
 void VQA_DispatchFrameChunks(VQAHandleP *vqap, long frame);
 void VQA_ResetCache(VQAHandleP *vqap);
-long VQA_Configure_Buffer(VQAHandleP *vqap);
+VQAErrorType VQA_Configure_Buffer(VQAHandleP *vqap);
 void VQA_SetTimer(VQAHandleP *vqap, long time);
 unsigned long VQA_GetTime(VQAHandleP *vqap);
 void VQA_StartAudio(VQAHandleP *vqap);
 void VQA_StopAudio(VQAHandleP *vqap);
-long VQA_LoadFrame(VQAHandleP *vqap, long flags);
+VQAErrorType VQA_LoadFrame(VQAHandleP *vqap, long flags);
 long User_Update(VQAHandle *vqa);
-long VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode);
-long VQA_SetLoop_Internal(VQAHandle *vqa, int start, int end, int iterations, int mode);
+VQAErrorType VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode);
+VQAErrorType VQA_SetLoop_Internal(VQAHandle *vqa, int start, int end, int iterations, int mode);
 void VQA_Reset(VQAHandle *vqap);
-long VQA_Configure_Drawer(VQAHandleP *vqap);
+VQAErrorType VQA_Configure_Drawer(VQAHandleP *vqap);
 long VQA_NumFramesWithPalettes(VQAHandleP *vqap);
 
-long VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force);
+VQAErrorType VQA_ReloadPalette(VQAHandleP *vqap, long framenum, int force);
 VQABool VQA_IsFrameStartOfLoop(VQAHandleP *vqap, long framenum);
-long VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool preloadaudio, VQABool reset_state, VQABool &skipcodebook);
+VQAErrorType VQA_SeekGroup(VQAHandleP *vqap, long framenum, long groupsize, VQABool preloadaudio, VQABool reset_state, VQABool &skipcodebook);
 
 
 /*---------------------------------------------------------------------------
  * PRIVATE DECLARATIONS
  *-------------------------------------------------------------------------*/
 
-long PrimeBuffers(VQAHandle *vqa);
+VQAErrorType PrimeBuffers(VQAHandle *vqa);
 
-long Load_FINF(VQAHandleP *vqap, unsigned long iffsize);
+VQAErrorType Load_FINF(VQAHandleP *vqap, unsigned long iffsize);
 
-long Load_CINF(VQAHandleP *vqap);
-long Load_PINF(VQAHandleP *vqap);
-long Load_LINF(VQAHandleP *vqap);
-long Load_CLIP(VQAHandleP *vqap, unsigned long iffsize);
-long Load_MFCI(VQAHandleP *vqap);
-long Load_MSCI(VQAHandleP *vqap);
+VQAErrorType Load_CINF(VQAHandleP *vqap);
+VQAErrorType Load_PINF(VQAHandleP *vqap);
+VQAErrorType Load_LINF(VQAHandleP *vqap);
+VQAErrorType Load_CLIP(VQAHandleP *vqap, unsigned long iffsize);
+VQAErrorType Load_MFCI(VQAHandleP *vqap);
+VQAErrorType Load_MSCI(VQAHandleP *vqap);
 
 intptr_t __cdecl VQA_Memory_Handler(VQAHandle *vqa, long action, void *buffer, long nbytes);
 intptr_t __cdecl Disk_VQA_Stream_Handler(VQAHandle *vqa, long action, void *buffer, long nbytes);
@@ -143,7 +143,7 @@ extern void __cdecl UnVQ_Nop(uint8_t *codebook, uint8_t *pointers,
 #define OPEN_CAPTIONS (1<<2)
 #define OPEN_EVA      (1<<3)
 
-long VQA_Open(char const *filename, VQAConfig *_config, VQAHandle **handle)
+VQAErrorType VQA_Open(char const *filename, VQAConfig *_config, VQAHandle **handle)
 {
 	VQAHandle   *vqa;
 	VQAHandleP  *vqap;
@@ -1194,7 +1194,7 @@ long VQA_SeekFrame(VQAHandle *vqa, long framenum, long fromwhere)
 }
 
 
-long VQA_SetUnVQ(VQAHandle *vqa, UNVQ_FUNC unvq1, UNVQ_FUNC unvq2)
+VQAErrorType VQA_SetUnVQ(VQAHandle *vqa, UNVQ_FUNC unvq1, UNVQ_FUNC unvq2)
 {
 	VQAHandleP *vqap = (VQAHandleP *)vqa;
 
@@ -1241,7 +1241,7 @@ long VQA_SetUnVQ(VQAHandle *vqa, UNVQ_FUNC unvq1, UNVQ_FUNC unvq2)
 *
 ****************************************************************************/
 
-long VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long width, unsigned long height, long xpos, long ypos)
+VQAErrorType VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long width, unsigned long height, long xpos, long ypos)
 {
 	long origin;
 	VQAHeader *header;
@@ -1335,7 +1335,7 @@ long VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long wid
 }
 
 
-long VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode)
+VQAErrorType VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode)
 {
 	VQAHandleP *vqap = (VQAHandleP *)vqa;
 	VQAConfig *config = &vqap->Config;
@@ -1353,7 +1353,7 @@ long VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode)
 	int start = data->StartFrame;
 	int end = data->EndFrame;
 	vqap->LoopID = id;
-	long rc = VQA_SetLoop_Internal(vqa, start, end, iterations, mode);
+	VQAErrorType rc = VQA_SetLoop_Internal(vqa, start, end, iterations, mode);
 	if (rc == VQAERR_NONE) {
 		vqap->LoopID = id;
 	}
@@ -1374,11 +1374,11 @@ long VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode)
 /// <param name="iterations">Number of times to repeat the loop. A negative value loops forever.</param>
 /// <param name="mode">One of the VQALOOP_ modes.</param>
 /// <returns>Returns with VQAERR_NONE, or VQAERR_SETLOOP if the loop could not be set.</returns>
-long VQA_SetLoop_Internal(VQAHandle *vqa, int start, int end, int iterations, int mode)
+VQAErrorType VQA_SetLoop_Internal(VQAHandle *vqa, int start, int end, int iterations, int mode)
 {
 	VQAHandleP *vqap = (VQAHandleP *)vqa;
 
-	long rc = VQAERR_NONE;
+	VQAErrorType rc = VQAERR_NONE;
 
 	if (start < vqap->NumFrames && end < vqap->NumFrames && start < end && mode >= VQALOOP_NORMAL && mode < VQALOOP_3) {
 
@@ -1585,7 +1585,7 @@ char const *VQA_Version(void)
 }
 
 
-long VQA_GetClipping(VQAHandleP *vqap, int & clipw, long & cliph)
+VQAErrorType VQA_GetClipping(VQAHandleP *vqap, int & clipw, long & cliph)
 {
 	if (vqap->Clipper.Width > 0) {
 		clipw = vqap->Clipper.Width;
@@ -1598,7 +1598,7 @@ long VQA_GetClipping(VQAHandleP *vqap, int & clipw, long & cliph)
 }
 
 
-long VQA_GetBlockInfo(VQAHandle *vqa, long & blockw, long & blockh, long & clrmode)
+VQAErrorType VQA_GetBlockInfo(VQAHandle *vqa, long & blockw, long & blockh, long & clrmode)
 {
 	VQAHandleP *vqap = (VQAHandleP *)vqa;
 	VQAHeader *header;
@@ -1670,7 +1670,7 @@ long User_Update(VQAHandle *vqa)
 	VQAFrameNode *curframe;
 	VQADrawer *drawer;
 	VQAConfig *config;
-	long    rc = 0;
+	VQAErrorType    rc = VQAERR_OK;
 
 	/* Dereference data members for quicker access. */
 	vqap = (VQAHandleP *)vqa;
@@ -1727,7 +1727,7 @@ long VQA_NumFramesWithPalettes(VQAHandleP *vqap)
 }
 
 
-long VQA_GetXYPos(VQAHandleP *vqap, int & x, long & y)
+VQAErrorType VQA_GetXYPos(VQAHandleP *vqap, int & x, long & y)
 {
 	VQAHeader *header;
 

--- a/code/vqalib/vqaplay.h
+++ b/code/vqalib/vqaplay.h
@@ -116,32 +116,34 @@ class VQAClass;
 #define INFINITE_LOOP	-1
 
 /* Error/Status conditions */
-#define VQAERR_OK        0
-#define VQAERR_NONE     -1  /* No error */
-#define	VQAERR_EOF      -2  /* Valid end of file */
-#define VQAERR_OPEN     -3  /* Unable to open */
-#define	VQAERR_READ     -4  /* Read error */
-#define VQAERR_WRITE    -5  /* Write error */
-#define VQAERR_SEEK     -6  /* Seek error */
-#define VQAERR_NOTVQA   -7  /* Not a valid VQA file. */
-#define VQAERR_NOMEM    -8  /* Unable to allocate memory */
-#define	VQAERR_NOBUFFER -9  /* No buffer avail for load/draw */
-#define	VQAERR_NOT_TIME -10 /* Not time for frame yet */
-#define	VQAERR_SLEEPING -11 /* Function is in a sleep state */
-#define VQAERR_VIDEO    -12 /* Video related error. */
-#define VQAERR_AUDIO    -13 /* Audio related error. */
-#define VQAERR_PAUSED   -14 /* In paused state. */
-#define VQAERR_NOTIMER  -15
-#define VQAERR_NORATE   -16
-#define VQAERR_NOCONFIG -17
-#define VQAERR_NOAUDSIZ -18
-#define VQAERR_AUDSYNC  -19
-#define VQAERR_BADBLOCK -20
-#define VQAERR_NOAHANDL -21
-#define VQAERR_SKIPDRAW -22
-#define VQAERR_SETLOOP  -23
-#define VQAERR_SETBUFFR -24
-#define VQAERR_FORCEDRW -25
+enum VQAErrorType : int32_t {
+	VQAERR_OK       = 0,
+	VQAERR_NONE     = -1,	/* No error */
+	VQAERR_EOF      = -2,	/* Valid end of file */
+	VQAERR_OPEN     = -3,	/* Unable to open */
+	VQAERR_READ     = -4,	/* Read error */
+	VQAERR_WRITE    = -5,	/* Write error */
+	VQAERR_SEEK     = -6,	/* Seek error */
+	VQAERR_NOTVQA   = -7,	/* Not a valid VQA file. */
+	VQAERR_NOMEM    = -8,	/* Unable to allocate memory */
+	VQAERR_NOBUFFER = -9,	/* No buffer avail for load/draw */
+	VQAERR_NOT_TIME = -10,	/* Not time for frame yet */
+	VQAERR_SLEEPING = -11,	/* Function is in a sleep state */
+	VQAERR_VIDEO    = -12,	/* Video related error. */
+	VQAERR_AUDIO    = -13,	/* Audio related error. */
+	VQAERR_PAUSED   = -14,	/* In paused state. */
+	VQAERR_NOTIMER  = -15,
+	VQAERR_NORATE   = -16,
+	VQAERR_NOCONFIG = -17,
+	VQAERR_NOAUDSIZ = -18,
+	VQAERR_AUDSYNC  = -19,
+	VQAERR_BADBLOCK = -20,
+	VQAERR_NOAHANDL = -21,
+	VQAERR_SKIPDRAW = -22,
+	VQAERR_SETLOOP  = -23,
+	VQAERR_SETBUFFR = -24,
+	VQAERR_FORCEDRW = -25
+};
 
 /* Event flags. */
 #define VQAEVENT_0			0
@@ -398,22 +400,22 @@ void VQA_Reset(VQAHandle *vqa);
 //VQAHandle *VQA_Alloc(void);
 //void VQA_Init(VQAHandle *, long (*)());
 /* File routines. */
-long VQA_Open(char const *, _VQAConfig *, VQAHandle **vqa);
+VQAErrorType VQA_Open(char const *, _VQAConfig *, VQAHandle **vqa);
 void VQA_Free(VQAHandle *vqa);
 void VQA_Close(VQAHandle *vqa);
 long VQA_Play(VQAHandle *vqa, long, int flags);
 long VQA_SeekFrame(VQAHandle *vqa, long framenum, long fromwhere);
 long VQA_SetStop(VQAHandle *vqa, long stop);
-long VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode);
-long VQA_SetLoop_Internal(VQAHandle *vqa, int start, int end, int iterations, int mode);
+VQAErrorType VQA_SetLoop(VQAHandle *vqa, int id, int iterations, int mode);
+VQAErrorType VQA_SetLoop_Internal(VQAHandle *vqa, int start, int end, int iterations, int mode);
 
-long VQA_SetUnVQ(VQAHandle *vqa, UNVQ_FUNC unvq1, UNVQ_FUNC unvq2);
+VQAErrorType VQA_SetUnVQ(VQAHandle *vqa, UNVQ_FUNC unvq1, UNVQ_FUNC unvq2);
 
-long VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long width, unsigned long height, long xpos, long ypos);
-long VQA_ResetLastFrameNum(VQAHandle *vqa);
+VQAErrorType VQA_Set_DrawBuffer(VQAHandle *vqa, unsigned char *buffer, unsigned long width, unsigned long height, long xpos, long ypos);
+VQAErrorType VQA_ResetLastFrameNum(VQAHandle *vqa);
 
 /* Information/statistics access routines. */
-long VQA_GetBlockInfo(VQAHandle *vqa, long & blockw, long & blockh, long & clrmode);
+VQAErrorType VQA_GetBlockInfo(VQAHandle *vqa, long & blockw, long & blockh, long & clrmode);
 
 #endif /* VQAPLAY_H */
 

--- a/code/vqalib/vqaplayp.h
+++ b/code/vqalib/vqaplayp.h
@@ -446,8 +446,8 @@ typedef struct _VQAAudio {
 #define VQAABUFF_ALTLOOP	(1<<2)	// use alternative loop buffer
 
 // Draw_Frame and Page_Flip functions must be this type
-typedef long (*VQAD_FUNC)(VQAHandle *vqa);
-typedef long (*VQAP_FUNC)(VQAHandle *vqa);
+typedef VQAErrorType (*VQAD_FUNC)(VQAHandle *vqa);
+typedef VQAErrorType (*VQAP_FUNC)(VQAHandle *vqa);
 
 struct VQA_Array_Data {
 	void			**Ptr;
@@ -759,8 +759,8 @@ typedef struct _VQAHandleP {
  *-------------------------------------------------------------------------*/
 
 /* Loader/Drawer system. */
-long VQA_LoadFrame(VQAHandle *vqa);
-long VQA_Configure_Drawer(VQAHandleP *vqap);
+VQAErrorType VQA_LoadFrame(VQAHandle *vqa);
+VQAErrorType VQA_Configure_Drawer(VQAHandleP *vqap);
 long User_Update(VQAHandle *vqa);
 
 /* Timer system. */
@@ -771,7 +771,7 @@ unsigned long VQA_GetMovieTime(VQAHandle *vqa);
 
 /* Audio system. */
 #if(VQAAUDIO_ON)
-long VQA_OpenAudio(VQAHandleP *vqap);
+VQAErrorType VQA_OpenAudio(VQAHandleP *vqap);
 void VQA_CloseAudio(VQAHandleP *vqap);
 void VQA_StartAudio(VQAHandleP *vqap);
 void VQA_PauseAudio(VQAHandleP *vqap);
@@ -785,7 +785,7 @@ long __cdecl VQA_AudioDoneCallback(VQAHandleP *vqap, void *);
 void VQA_InitMono(VQAHandleP *vqap);
 void VQA_UpdateMono(VQAHandleP *vqap);
 
-long AllocBuffers(VQAHandleP *vqap);
+VQAErrorType AllocBuffers(VQAHandleP *vqap);
 void FreeBuffers(VQAHandleP *vqap);
 
 #endif /* VQAPLAYP_H */


### PR DESCRIPTION
The 26 `VQAERR_*` macros become `enum VQAErrorType : int32_t`.

Left alone where the return is genuinely multiplexed: `VQA_Play`/`VQA_SeekFrame` (frame number or negative error), `VQA_H_FUNC` (pointer for `VQAEVENT_LOCK`), and a few returning counts or indices.

Found in passing: an `HRESULT` and a `VQAERR_*` sharing one variable in `Play_Audio_Handler`, a bare `-4` meaning `VQAERR_READ`, and two unsigned ints holding negative codes.