### PR TITLE
Use the in-game global retry timing while a launched match loads

### DIFF
--- a/code/spawner.cpp
+++ b/code/spawner.cpp
@@ -34,6 +34,7 @@
 #include "savever.h"
 #include "scenario.h"
 #include "session.h"
+#include "stimer.h"
 
 #include <algorithm>
 #include <cstdarg>
@@ -303,6 +304,10 @@ static bool Spawner_Wire_Network(void)
 	if (!Ipx.Init()) {
 		return(Spawner_Refuse("The network could not be opened."));
 	}
+
+	// Loading-screen progress goes out before the in-game timing is set, and the manager's
+	// default 33 ms retry floods a slow link.
+	Ipx.Set_Timing(TIMER_SECOND, (unsigned int)-1, 10 * TIMER_SECOND);
 
 	return(true);
 }

--- a/manual/content/formats/spawn-ini.md
+++ b/manual/content/formats/spawn-ini.md
@@ -152,7 +152,9 @@ match against other machines is a seed like any other rather than a draw from ch
 
 When a `[Tunnel]` section names a server, the match is played through it; otherwise each
 machine is reached straight at the address its section carries, while this machine listens
-on the port its own `Port` key names.
+on the port its own `Port` key names. Loading progress reaches the other machines with the
+in-game retry cadence: a second between retries and ten seconds before a report is given
+up.
 
 A tunnel server may run beside the game rather than across the internet, in which case
 `[Tunnel] Ip` is the loopback address. The tunnel's port and the number it knows this


### PR DESCRIPTION
A client-launched match exchanges loading progress over the global channel before Create_Connections sets the in-game timing, so it ran with the IPX manager's constructor defaults: a retry every 33 ms and a 1 s timeout per packet. Under a 24 kbit/s link the impaired-link rig queued 227 packets and the start was delayed by 24 s. The spawner now sets the in-game global timing (1 s retry, 10 s timeout) as soon as the network is open, before loading starts. The launch-file page notes the cadence.

Verified with two spawned instances through the UDP impairment proxy at 24 kbit/s and on an unimpaired loopback; NetTiming and NetContract are unaffected, and the manual check passes.
