### PR TITLE
Decouple portable sources from MSVC-only headers

### DIFF
--- a/code/arraylist.h
+++ b/code/arraylist.h
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <math.h>
-#include <new.h>
+#include <new>
 
 
 template <class T>

--- a/code/conquer.cpp
+++ b/code/conquer.cpp
@@ -131,7 +131,9 @@
 #include <direct.h>
 #include <dos.h>
 #include <fcntl.h>
+#ifdef _WIN32
 #include <io.h>
+#endif
 #include <share.h>
 #include <span>
 

--- a/code/data.cpp
+++ b/code/data.cpp
@@ -39,7 +39,7 @@
 
 #include "utf8.h"
 
-#include <new.h>
+#include <new>
 
 HINSTANCE LanguageResources;
 

--- a/code/sha.cpp
+++ b/code/sha.cpp
@@ -78,7 +78,7 @@ void SHAEngine::Process_Partial(void const * & data, int & length)
 	**	Attach as many bytes as possible from the source data into
 	**	the staging buffer.
 	*/
-	int add_count = std::min((int)length, SRC_BLOCK_SIZE - PartialCount);
+	int add_count = std::min<int>((int)length, SRC_BLOCK_SIZE - PartialCount);
 	memcpy(&Partial[PartialCount], data, add_count);
 	data = ((char const *&)data) + add_count;
 	PartialCount += add_count;

--- a/code/sha.h
+++ b/code/sha.h
@@ -35,7 +35,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <new.h>
+#include <new>
 
 
 /*

--- a/code/startup.cpp
+++ b/code/startup.cpp
@@ -161,7 +161,9 @@
 #include <shellapi.h>
 
 #include <conio.h>
+#ifdef _WIN32
 #include <io.h>
+#endif
 #include <cfloat>
 #include <string>
 #include <vector>

--- a/code/techtype.cpp
+++ b/code/techtype.cpp
@@ -44,7 +44,7 @@
 #include "voc.hh"
 
 #include <algorithm>
-#include <new.h>
+#include <new>
 
 
 /***************************************************************************

--- a/code/visualc.h
+++ b/code/visualc.h
@@ -116,6 +116,9 @@
 // Single precision pi, for the float paths that would otherwise round M_PI at every use.
 #define M_FPI 3.141592654f
 
+#endif
+
+
 /*
 **	Macros to convert between degrees and radians
 */
@@ -133,7 +136,4 @@
 
 #ifndef DEG_TO_RADF
 #define DEG_TO_RADF(x)	(((float)x)*M_PI/180.0f)
-#endif
-
-
 #endif

--- a/code/vqalib/cmp.h
+++ b/code/vqalib/cmp.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #if defined(__WATCOMC__) || defined(_MSC_VER)

--- a/code/vqalib/dstream.cpp
+++ b/code/vqalib/dstream.cpp
@@ -45,7 +45,9 @@
 #include	"vqaplayp.h"
 #include	<stdio.h>
 #include	<fcntl.h>
+#ifdef _WIN32
 #include	<io.h>
+#endif
 #include	<string.h>
 
 

--- a/code/vqalib/dstream.cpp
+++ b/code/vqalib/dstream.cpp
@@ -47,6 +47,8 @@
 #include	<fcntl.h>
 #ifdef _WIN32
 #include	<io.h>
+#else
+#include	<unistd.h>
 #endif
 #include	<string.h>
 

--- a/code/vqalib/dstream.cpp
+++ b/code/vqalib/dstream.cpp
@@ -50,6 +50,10 @@
 #endif
 #include	<string.h>
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 
 long __cdecl Disk_VQA_Stream_Handler(VQAHandle *vqa, long action, void *buffer, long nbytes)
 {

--- a/code/wwfile.h
+++ b/code/wwfile.h
@@ -40,7 +40,9 @@
 
 #include <cstddef>
 #include <cstdio>
+#ifdef _WIN32
 #include <io.h>
+#endif
 
 #ifndef SEEK_SET
 #define SEEK_SET					0	// Seek from start of file.


### PR DESCRIPTION
`<cstddef>` where `size_t` is used, `<new>` for `<new.h>`, `<io.h>` guarded with `_WIN32`, and `visualc.h`'s angle macros moved outside its `_MSC_VER` block. No behaviour change, nothing Windows-visible.