### PR TITLE
Add an experimental native build for the host platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ elseif(MSVC)
     endif()
 elseif(OPENTS_EXPERIMENTAL_NATIVE)
     message(STATUS "OpenTS: configuring an unsupported native build for the host platform.")
+
+    # The tree declares imports and exports with __declspec throughout, which clang only
+    # accepts with the Microsoft extensions enabled.
+    add_compile_options(-fms-extensions)
 else()
     message(FATAL_ERROR
         "OpenTS requires the Visual Studio 2022 MSVC toolchain. "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(OPENTS_VERSION_PRERELEASE "")
 option(OPENTS_OFFICIAL_BUILD "Build as an official release of the declared version" OFF)
 
 option(OPENTS_EXPERIMENTAL_CLANG_CL "Build with clang-cl using the MSVC ABI" OFF)
+option(OPENTS_EXPERIMENTAL_NATIVE "Configure a native build for the host platform" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
    AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
@@ -24,14 +25,20 @@ elseif(MSVC)
     if(MSVC_VERSION LESS 1930)
         message(FATAL_ERROR "OpenTS requires MSVC 19.30 or newer.")
     endif()
+elseif(OPENTS_EXPERIMENTAL_NATIVE)
+    message(STATUS "OpenTS: configuring an unsupported native build for the host platform.")
 else()
     message(FATAL_ERROR
         "OpenTS requires the Visual Studio 2022 MSVC toolchain. "
         "For the unsupported clang-cl experiment, configure with "
-        "-DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/clang-cl-msvc.cmake.")
+        "-DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/clang-cl-msvc.cmake. "
+        "For the unsupported native build, configure with "
+        "-DOPENTS_EXPERIMENTAL_NATIVE=ON.")
 endif()
 
-enable_language(RC)
+if(WIN32)
+    enable_language(RC)
+endif()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ elseif(OPENTS_EXPERIMENTAL_NATIVE)
     # The tree declares imports and exports with __declspec throughout, which clang only
     # accepts with the Microsoft extensions enabled.
     add_compile_options(-fms-extensions)
+
+    # Saved games serialize pointer fields at their native width.
+    if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
+        message(WARNING
+            "OpenTS: this native build has ${CMAKE_SIZEOF_VOID_P}-byte pointers. Saved games "
+            "it writes are not interchangeable with a supported 32-bit build's.")
+    endif()
 else()
     message(FATAL_ERROR
         "OpenTS requires the Visual Studio 2022 MSVC toolchain. "

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE STRING "" FORCE)
 
 # OpenTS currently supports 32-bit (x86) builds only.
-if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
+if(WIN32 AND NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
     message(FATAL_ERROR "OpenTS must be built as 32-bit x86. Reconfigure with -A Win32.")
 endif()
 
@@ -156,7 +156,7 @@ set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/bgfxbackend.cpp" PROPER
         "${BGFX_ROOT}/include;${CMAKE_SOURCE_DIR}/thirdparty/bgfx.cmake/bx/include;${BGFX_ROOT}/examples/common/imgui"
     COMPILE_DEFINITIONS
         "BX_CONFIG_DEBUG=$<IF:$<CONFIG:Debug>,1,$<BOOL:${BX_CONFIG_DEBUG}>>"
-    COMPILE_OPTIONS "/Zc:preprocessor"
+    COMPILE_OPTIONS "$<$<BOOL:${MSVC}>:/Zc:preprocessor>"
 )
 
 # bx rewrites __stdcall while its headers are being parsed by clang-cl.  Force the
@@ -318,12 +318,14 @@ add_custom_command(TARGET OpenTS POST_BUILD
         "${TS_RUN_DIR}"
 )
 
-# Copy the linker-generated .pdb alongside the exe
-add_custom_command(TARGET OpenTS POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "$<TARGET_PDB_FILE:OpenTS>"
-        "${TS_RUN_DIR}"
-)
+# Copy the linker-generated .pdb alongside the exe. Only the MSVC linker writes one.
+if(MSVC)
+    add_custom_command(TARGET OpenTS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_PDB_FILE:OpenTS>"
+            "${TS_RUN_DIR}"
+    )
+endif()
 
 # Copy the linker-generated .map (sits next to the exe, no GenEx for it)
 add_custom_command(TARGET OpenTS POST_BUILD

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -97,6 +97,19 @@ The toolchain requires `clang-cl`, `lld-link`, `llvm-lib`, `llvm-mt`, and
 `llvm-rc` on `PATH`. It exports `compile_commands.json`; one configuration in
 `.vscode/c_cpp_properties.clang.example.json` reads that file for IntelliSense.
 
+## Experimental native build
+
+An unsupported native build for the host platform is available for portability
+work. It does not expand the supported build matrix or establish runtime
+behavior.
+
+```bash
+cmake -S . -B build/native -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DOPENTS_EXPERIMENTAL_NATIVE=ON
+cmake --build build/native
+```
+
 ## Build from Visual Studio Code
 
 With the recommended extensions installed, the repository provides:

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -100,15 +100,25 @@ The toolchain requires `clang-cl`, `lld-link`, `llvm-lib`, `llvm-mt`, and
 ## Experimental native build
 
 An unsupported native build for the host platform is available for portability
-work. It does not expand the supported build matrix or establish runtime
-behavior.
+work. It configures; the engine target does not compile yet. It does not expand
+the supported build matrix or establish runtime behavior.
 
 ```bash
 cmake -S . -B build/native -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DOPENTS_EXPERIMENTAL_NATIVE=ON
-cmake --build build/native
 ```
+
+Building the generated tree compiles the vendored dependencies and stops on
+every engine source, because `code/CMakeLists.txt` passes the MSVC flag set
+unconditionally. `/arch:SSE2` and `/fp:precise` carry the float semantics the
+simulation depends on, so a native equivalent is a decision to make rather than
+a translation. Windows headers and import libraries are named unconditionally
+as well.
+
+A native build takes the host's pointer width, and saved games serialize pointer
+fields at that width, so a 64-bit build's saves are not interchangeable with a
+supported build's.
 
 ## Build from Visual Studio Code
 


### PR DESCRIPTION
An opt-in `OPENTS_EXPERIMENTAL_NATIVE` configures a native build for the host. The resource compiler, the 32-bit requirement, the PDB copy and `/Zc:preprocessor` are guarded, and `-fms-extensions` is enabled for the tree's `__declspec`. Every hunk is a guard, so Windows is unchanged.

Also "`language\language.h`" -> "`language/language.h`" in 51 files; a backslash only resolves on Windows.