### PR TITLE
Make the VQA seek command's origin explicit

### DIFF
--- a/code/vqa.cpp
+++ b/code/vqa.cpp
@@ -300,15 +300,15 @@ long VQAClass::CacheHandler(long action, void * buffer, long nbytes)
 
 		case VQACMD_SEEK:
 			switch (VQA_DecodeSeekOrigin(buffer)) {
-				case 1:
+				case SEEK_CUR:
 					Cache.file_buffer_pos += nbytes;
 					rc = 0;
 					break;
-				case 0:
+				case SEEK_SET:
 					Cache.file_buffer_pos = nbytes;
 					rc = 0;
 					break;
-				case 2:
+				case SEEK_END:
 					Cache.file_buffer_pos = Cache.file_size - nbytes - 1;
 					rc = 0;
 					break;

--- a/code/vqa.cpp
+++ b/code/vqa.cpp
@@ -846,10 +846,9 @@ long VQAClass::CCFileHandler(long action, void * buffer, long nbytes)
 			break;
 
 		/*
-		**	VQACMD_SEEK asks that you perform a seek relative to the current
-		**	position. NBytes is a signed number, indicating seek direction
-		** (positive for forward, negative for backward). Buffer has no meaning
-		**	here.
+		**	VQACMD_SEEK asks that you perform a seek from the origin Buffer
+		**	names, which is a SEEK_SET, SEEK_CUR or SEEK_END value cast to a
+		**	pointer. NBytes is the signed offset from that origin.
 		**
 		**	Any error code returned will be remapped by VQA library into
 		**	VQAERR_SEEK.
@@ -973,10 +972,9 @@ long VQAClass::MixFileHandler(long action, void * buffer, long nbytes)
 			break;
 
 		/*
-		**	VQACMD_SEEK asks that you perform a seek relative to the current
-		**	position. NBytes is a signed number, indicating seek direction
-		** (positive for forward, negative for backward). Buffer has no meaning
-		**	here.
+		**	VQACMD_SEEK asks that you perform a seek from the origin Buffer
+		**	names, which is a SEEK_SET, SEEK_CUR or SEEK_END value cast to a
+		**	pointer. NBytes is the signed offset from that origin.
 		**
 		**	Any error code returned will be remapped by VQA library into
 		**	VQAERR_SEEK.

--- a/code/vqa.cpp
+++ b/code/vqa.cpp
@@ -299,7 +299,7 @@ long VQAClass::CacheHandler(long action, void * buffer, long nbytes)
 			break;
 
 		case VQACMD_SEEK:
-			switch ((int)(intptr_t)buffer) {
+			switch (VQA_DecodeSeekOrigin(buffer)) {
 				case 1:
 					Cache.file_buffer_pos += nbytes;
 					rc = 0;
@@ -855,17 +855,17 @@ long VQAClass::CCFileHandler(long action, void * buffer, long nbytes)
 		**	VQAERR_SEEK.
 		*/
 		case VQACMD_SEEK:
-			error = (FileHandle.Seek(nbytes, (int)(intptr_t)buffer) == 0);
+			error = (FileHandle.Seek(nbytes, VQA_DecodeSeekOrigin(buffer)) == 0);
 			break;
 
 		case VQACMD_SEEKPEEK:
 			if (nbytes > 0) {
-				error = FileHandle.Seek(nbytes - sizeof(tmp), (int)(intptr_t)buffer) == 0;
+				error = FileHandle.Seek(nbytes - sizeof(tmp), VQA_DecodeSeekOrigin(buffer)) == 0;
 				if (error == 0) {
 					error = FileHandle.Read(&tmp, sizeof(tmp)) != sizeof(tmp);
 				}
 			} else {
-				error = FileHandle.Seek(nbytes, (int)(intptr_t)buffer) == 0;
+				error = FileHandle.Seek(nbytes, VQA_DecodeSeekOrigin(buffer)) == 0;
 				if (error == 0) {
 					error = FileHandle.Read(&tmp, sizeof(tmp)) != sizeof(tmp);
 					if (error == 0) {
@@ -982,17 +982,17 @@ long VQAClass::MixFileHandler(long action, void * buffer, long nbytes)
 		**	VQAERR_SEEK.
 		*/
 		case VQACMD_SEEK:
-			error = (FileHandle.Seek(nbytes, (int)(intptr_t)buffer) == 0);
+			error = (FileHandle.Seek(nbytes, VQA_DecodeSeekOrigin(buffer)) == 0);
 			break;
 
 		case VQACMD_SEEKPEEK:
 			if (nbytes > 0) {
-				error = FileHandle.Seek(nbytes - sizeof(tmp), (int)(intptr_t)buffer) == 0;
+				error = FileHandle.Seek(nbytes - sizeof(tmp), VQA_DecodeSeekOrigin(buffer)) == 0;
 				if (error == 0) {
 					error = FileHandle.Read(&tmp, sizeof(tmp)) != sizeof(tmp);
 				}
 			} else {
-				error = FileHandle.Seek(nbytes, (int)(intptr_t)buffer) == 0;
+				error = FileHandle.Seek(nbytes, VQA_DecodeSeekOrigin(buffer)) == 0;
 				if (error == 0) {
 					error = FileHandle.Read(&tmp, sizeof(tmp)) != sizeof(tmp);
 					if (error == 0) {

--- a/code/vqalib/dstream.cpp
+++ b/code/vqalib/dstream.cpp
@@ -113,7 +113,7 @@ intptr_t __cdecl Disk_VQA_Stream_Handler(VQAHandle *vqa, long action, void *buff
 					error = read(fh, &temp, 1) != 1;
 				}
 				if (error == 0) {
-					error = lseek(fh, -1, 1) == -1;
+					error = lseek(fh, -1, SEEK_CUR) == -1;
 				}
 			}
 			break;
@@ -198,12 +198,12 @@ intptr_t __cdecl Memory_VQA_Stream_Handler(VQAHandle *vqa, long action, void *bu
 		case VQACMD_SEEKPEEK:
 			switch (VQA_DecodeSeekOrigin(buffer)) {
 
-				case 1:
+				case SEEK_CUR:
 					cache->Offset += nbytes;
 					error = 0;
 					break;
 
-				case 0:
+				case SEEK_SET:
 					p = cache->FileOffset;
 					if (nbytes >= p) {
 						cache->Offset = nbytes - p;

--- a/code/vqalib/dstream.cpp
+++ b/code/vqalib/dstream.cpp
@@ -89,10 +89,9 @@ intptr_t __cdecl Disk_VQA_Stream_Handler(VQAHandle *vqa, long action, void *buff
 			error = 1;
 			break;
 
-		/* VQACMD_SEEK asks that you perform a seek relative to the current
-		 * position. NBytes is a signed number, indicating seek direction
-		 * (positive for forward, negative for backward). Buffer has no meaning
-		 * here.
+		/* VQACMD_SEEK asks that you perform a seek from the origin Buffer
+		 * names, which is a SEEK_SET, SEEK_CUR or SEEK_END value cast to a
+		 * pointer. NBytes is the signed offset from that origin.
 		 *
 		 * Any error code returned will be remapped by VQA library into
 		 * VQAERR_SEEK.
@@ -186,10 +185,9 @@ intptr_t __cdecl Memory_VQA_Stream_Handler(VQAHandle *vqa, long action, void *bu
 			error = 1;
 			break;
 
-		/* VQACMD_SEEK asks that you perform a seek relative to the current
-		 * position. NBytes is a signed number, indicating seek direction
-		 * (positive for forward, negative for backward). Buffer has no meaning
-		 * here.
+		/* VQACMD_SEEK asks that you perform a seek from the origin Buffer
+		 * names, which is a SEEK_SET, SEEK_CUR or SEEK_END value cast to a
+		 * pointer. NBytes is the signed offset from that origin.
 		 *
 		 * Any error code returned will be remapped by VQA library into
 		 * VQAERR_SEEK.

--- a/code/vqalib/dstream.cpp
+++ b/code/vqalib/dstream.cpp
@@ -98,17 +98,17 @@ intptr_t __cdecl Disk_VQA_Stream_Handler(VQAHandle *vqa, long action, void *buff
 		 * VQAERR_SEEK.
 		 */
 		case VQACMD_SEEK:
-			error = (lseek(fh, nbytes, (int)(intptr_t)buffer) == -1);
+			error = (lseek(fh, nbytes, VQA_DecodeSeekOrigin(buffer)) == -1);
 			break;
 
 		case VQACMD_SEEKPEEK:
 			if (nbytes > 0) {
-				error = lseek(fh, nbytes - 1, (int)(intptr_t)buffer) == -1;
+				error = lseek(fh, nbytes - 1, VQA_DecodeSeekOrigin(buffer)) == -1;
 				if (error == 0) {
 					error = read(fh, &temp, 1) != 1;
 				}
 			} else {
-				error = lseek(fh, nbytes, (int)(intptr_t)buffer) == -1;
+				error = lseek(fh, nbytes, VQA_DecodeSeekOrigin(buffer)) == -1;
 				if (error == 0) {
 					error = read(fh, &temp, 1) != 1;
 				}
@@ -196,7 +196,7 @@ intptr_t __cdecl Memory_VQA_Stream_Handler(VQAHandle *vqa, long action, void *bu
 		 */
 		case VQACMD_SEEK:
 		case VQACMD_SEEKPEEK:
-			switch ((intptr_t)buffer) {
+			switch (VQA_DecodeSeekOrigin(buffer)) {
 
 				case 1:
 					cache->Offset += nbytes;

--- a/code/vqalib/loader.cpp
+++ b/code/vqalib/loader.cpp
@@ -260,7 +260,7 @@ long VQA_LoadFrame(VQAHandleP *vqap, long flags)
 
 				if (tocache > 0) {
 					if (config->StreamHandler != Memory_VQA_Stream_Handler) {
-						config->StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, NULL, foffset);
+						config->StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, (void *)SEEK_SET, foffset);
 					}
 					if (config->StreamHandler((VQAHandle *)vqap, VQACMD_READ, &cache->Ptr[cache->Offset], tocache)) {
 						return -4;
@@ -1074,7 +1074,7 @@ long VQA_SeekLoop(VQAHandleP *vqap, long framenum, long flags)
 			needs_seek = true;
 		}
 		cache->Offset = 0;
-	} else if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, 0, VQAFRAME_OFFSET(foff[framenum])) != 0) {
+	} else if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, (void *)SEEK_SET, VQAFRAME_OFFSET(foff[framenum])) != 0) {
 		return(VQAERR_SEEK);
 	}
 
@@ -1083,7 +1083,7 @@ long VQA_SeekLoop(VQAHandleP *vqap, long framenum, long flags)
 	}
 
 	if (rc == VQAERR_NONE) {
-		if (needs_seek && vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_SEEKPEEK, 0, cache->FileOffset + cache->Bytes) != 0) {
+		if (needs_seek && vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_SEEKPEEK, (void *)SEEK_SET, cache->FileOffset + cache->Bytes) != 0) {
 			return(VQAERR_SEEK);
 		}
 	}
@@ -1826,7 +1826,7 @@ long Load_VQF(VQAHandleP *vqap, unsigned long frame_iffsize, char flags)
 
 		/* Skip any unknown chunks. */
 		if (skip == true) {
-			if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, (void *)1, PADSIZE(iffsize))) {
+			if (vqap->Config.StreamHandler((VQAHandle *)vqap, VQACMD_SEEK, (void *)SEEK_CUR, PADSIZE(iffsize))) {
 				return(VQAERR_SEEK);
 			}
 		}

--- a/code/vqalib/vqaplay.h
+++ b/code/vqalib/vqaplay.h
@@ -366,6 +366,15 @@ typedef struct _VQAHandle {
 #define VQACMD_SEEKPEEK 8
 #define VQACMD_SIZE     9
 
+/* VQACMD_SEEK and VQACMD_SEEKPEEK carry the seek origin in Buffer rather
+ * than a pointer. It comes back at pointer width before narrowing to the
+ * int origin that lseek and FileClass::Seek take.
+ */
+inline int VQA_DecodeSeekOrigin(void *buffer)
+{
+	return (int)(std::intptr_t)buffer;
+}
+
 #define VQAMEM_0		0
 #define VQAMEM_1		1
 #define VQAMEM_ALLOC	2


### PR DESCRIPTION
`VQACMD_SEEK` carries lseek's origin in its buffer argument, but the comment in both stream handlers said "Buffer has no meaning here", and the origin was spelled five ways across 15 call sites: `SEEK_CUR`, `SEEK_SET`, `NULL`, `0` and `(void *)1`. All of them now name the constant. The origin is also taken back through `intptr_t` rather than `int`, which truncated on a 64-bit target.

Behaviour preserved: `SEEK_SET` is `0` and `SEEK_CUR` is `1`, so every rename keeps the value it had.