### PR TITLE
Package third-party licenses with releases

### DIFF
--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -71,6 +71,22 @@ jobs:
       - name: Test
         run: ctest --test-dir build -C ${{ matrix.configuration }} --output-on-failure
 
+      - name: Stage license notices
+        shell: bash
+        run: |
+          cp LICENSE.md THIRD_PARTY_NOTICES.md artifact/
+          mkdir -p artifact/OpenTS_THIRD_PARTY_LICENSES
+          cp thirdparty/bgfx.cmake/bgfx/LICENSE artifact/OpenTS_THIRD_PARTY_LICENSES/bgfx.txt
+          cp thirdparty/bgfx.cmake/bx/LICENSE artifact/OpenTS_THIRD_PARTY_LICENSES/bx.txt
+          cp thirdparty/bgfx.cmake/bimg/LICENSE artifact/OpenTS_THIRD_PARTY_LICENSES/bimg.txt
+          cp thirdparty/bgfx.cmake/bgfx/3rdparty/directx-headers/LICENSE artifact/OpenTS_THIRD_PARTY_LICENSES/directx-headers.txt
+          cp thirdparty/bgfx.cmake/bx/include/tinystl/LICENSE artifact/OpenTS_THIRD_PARTY_LICENSES/tinystl.txt
+          cp thirdparty/bgfx.cmake/bimg/3rdparty/astc-encoder/LICENSE.txt artifact/OpenTS_THIRD_PARTY_LICENSES/astc-encoder.txt
+          cp thirdparty/licenses/khronos-opengl.txt artifact/OpenTS_THIRD_PARTY_LICENSES/khronos-opengl.txt
+          cat thirdparty/licenses/khronos-vulkan-notice.txt \
+              thirdparty/bgfx.cmake/bimg/3rdparty/astc-encoder/LICENSE.txt \
+              > artifact/OpenTS_THIRD_PARTY_LICENSES/khronos-vulkan.txt
+
       - name: Upload runtime files
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Package the release zip
         working-directory: artifact
-        run: zip "../OpenTS-${TAG}.zip" Game.exe Game.pdb Language.dll
+        run: >
+          zip -r "../OpenTS-${TAG}.zip"
+          Game.exe Game.pdb Language.dll
+          LICENSE.md THIRD_PARTY_NOTICES.md OpenTS_THIRD_PARTY_LICENSES
 
       - name: Attach the zip to the release
         env:

--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -55,9 +55,3 @@ change record credits the author where possible.
 
 - [C&C Mod Haven](https://discord.gg/k4SVuMm)
 - [CnCNet](https://cncnet.org)
-
-## Third-party libraries
-
-- [bgfx](https://github.com/bkaradzic/bgfx), with bx and bimg, vendored
-  through [bgfx.cmake](https://github.com/bkaradzic/bgfx.cmake)
-  (BSD-2-Clause).

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ completed through reverse engineering against the original executable.
 OpenTS is licensed under the GNU General Public License, version 3 or later.
 Material derived from Electronic Arts source remains subject to the additional
 GPL Section 7 terms in [LICENSE.md](LICENSE.md).
+[Third-party notices](THIRD_PARTY_NOTICES.md) identify bundled dependencies
+and their licenses.
 
 [ACKNOWLEDGEMENTS.md](ACKNOWLEDGEMENTS.md) thanks the people, projects, and
 communities whose work made OpenTS possible.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,19 @@
+# Third-party notices
+
+OpenTS binaries include software from the following projects. Each project
+remains under its own license and copyright notices.
+
+| Project                                                            | Use                                       | License      |
+| ------------------------------------------------------------------ | ----------------------------------------- | ------------ |
+| [bgfx](https://github.com/bkaradzic/bgfx)                          | Rendering                                 | BSD 2-Clause |
+| [bx](https://github.com/bkaradzic/bx)                              | Foundation library used by bgfx           | BSD 2-Clause |
+| [bimg](https://github.com/bkaradzic/bimg)                          | Image and texture processing used by bgfx | BSD 2-Clause |
+| [DirectX-Headers](https://github.com/microsoft/DirectX-Headers)    | Direct3D API headers used by bgfx         | MIT          |
+| [tinystl](https://github.com/mendsley/tinystl)                     | Containers used internally by bgfx        | BSD 2-Clause |
+| [astc-encoder](https://github.com/ARM-software/astc-encoder)       | ASTC texture processing used by bimg      | Apache-2.0   |
+| [OpenGL Registry](https://github.com/KhronosGroup/OpenGL-Registry) | OpenGL API headers used by bgfx           | MIT          |
+| [Vulkan Headers](https://github.com/KhronosGroup/Vulkan-Headers)   | Vulkan API headers used by bgfx           | Apache-2.0   |
+
+The source checkout keeps the license texts under `thirdparty/`. Binary
+packages reproduce the license texts for the components used by OpenTS under
+`OpenTS_THIRD_PARTY_LICENSES/`.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -161,15 +161,17 @@ the latest successful scheduled run attached to downloadable artifacts.
 Both use the reusable `Engine build` workflow. On a Windows runner with Visual
 Studio 2022, it configures and builds Win32 Debug and Release with the commands
 above, runs CTest, and uploads each configuration's executable, language
-library, and symbol file. Artifact names contain the configuration and short
-commit. Linker maps are omitted because the symbol files are sufficient.
+library, symbol file, and license notices. Artifact names contain the
+configuration and short commit. Linker maps are omitted because the symbol
+files are sufficient.
 After a successful pull-request build, `Engine build comment` maintains one
 pull-request comment with direct nightly.link downloads.
 
 Publishing a GitHub release runs `Engine release`. It builds the release commit
-with `-DOPENTS_OFFICIAL_BUILD=ON`, packages `Game.exe`, `Language.dll`, and
-`Game.pdb` in a zip named after the release tag, and attaches it to the
-release. It also appends notes generated from the manual's change records by
+with `-DOPENTS_OFFICIAL_BUILD=ON`, packages `Game.exe`, `Language.dll`,
+`Game.pdb`, and the project and third-party license notices in a zip named
+after the release tag, and attaches it to the release. It also appends notes
+generated from the manual's change records by
 `python manual/tools/manage.py release-notes`. See
 [Maintaining](../manual/MAINTAINING.md) for the full release procedure.
 

--- a/thirdparty/licenses/khronos-opengl.txt
+++ b/thirdparty/licenses/khronos-opengl.txt
@@ -1,0 +1,20 @@
+Copyright 2013-2025 The Khronos Group Inc.
+Copyright 2013-2020 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and/or associated documentation files (the "Materials"),
+to deal in the Materials without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Materials, and to permit persons to whom the
+Materials are furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS IN
+THE MATERIALS.

--- a/thirdparty/licenses/khronos-vulkan-notice.txt
+++ b/thirdparty/licenses/khronos-vulkan-notice.txt
@@ -1,0 +1,3 @@
+Copyright 2015-2026 The Khronos Group Inc.
+
+Licensed under the Apache License, Version 2.0. The license terms follow.


### PR DESCRIPTION
Packages OpenTS and third-party license notices with CI artifacts and release
archives

Only licenses for dependencies included in `Game.exe` are copied,
under a flat `OpenTS_THIRD_PARTY_LICENSES` directory, so distributed builds
carry the required notices without including unrelated licenses
