### PR TITLE
Arm the audio callbacks through a host timer

### DIFF
--- a/code/ahandle.cpp
+++ b/code/ahandle.cpp
@@ -18,6 +18,7 @@
 #include "dsaudio.h"
 #include "dbgprint.h"
 #include "gametime.h"
+#include "hosttimer.h"
 #include "vqaplayp.h"
 
 #include <cassert>
@@ -46,7 +47,7 @@ long __cdecl Play_Audio_Handler(VQAHandleP *vqap);
 long __cdecl Pause_Audio_Handler(VQAHandleP *vqap);
 long __cdecl Resume_Audio_Handler(VQAHandleP *vqap);
 long __cdecl Load_Audio_Handler(VQAHandleP *vqap, void *buffer, long nbytes);
-void CALLBACK AudioCallback(UINT uTimerID, UINT, DWORD dwUser, DWORD, DWORD);
+void AudioCallback(uint32_t timer, void * user);
 _STATIC unsigned long Get_Playback_Position(VQAHandle *vqa, Ahandle *handle, VQAConfig *config);
 
 _STATIC BOOL Move_HMI_Audio_Block_To_Direct_Sound_Buffer(VQAHandleP *vqap);
@@ -281,16 +282,12 @@ long __cdecl Open_Audio_Handler(VQAHandleP *vqap, AhandleInitParams *params, lon
 		_AHandleCallbackFunc1 = (AHANDLE_CALLBACK_1)params->Callback1;
 		_AHandleCallbackFunc2 = (AHANDLE_CALLBACK_2)params->Callback2;
 
-		DebugString("Calling timeBeginPeriod\n");
-		if (timeBeginPeriod(1000/VQA_TIMETICKS) != TIMERR_NOCANDO) {
-			DebugString("Creating VQ audio timer thread\n");
-			// Set orf 60hz timer
-			handle->TimerHandle = timeSetEvent ( 1000/VQA_TIMETICKS , 1 , AudioCallback , (DWORD)vqap , TIME_PERIODIC);
-			DebugString("VQ audio handler opened OK\n");
-			if (handle->TimerHandle != 0) {
-				return(VQAERR_NONE);
-			}
-			return(VQAERR_AUDIO);
+		DebugString("Arming the VQ audio timer\n");
+		// Set orf 60hz timer
+		handle->TimerHandle = Host_Timer_Arm(1000/VQA_TIMETICKS, AudioCallback, vqap);
+		DebugString("VQ audio handler opened OK\n");
+		if (handle->TimerHandle != 0) {
+			return(VQAERR_NONE);
 		}
 	}
 	return(VQAERR_AUDIO);
@@ -310,12 +307,9 @@ long __cdecl Close_Audio_Handler(VQAHandleP *vqap)
 			Stop_Audio_Handler(vqap);
 		}
 
-		DebugString("Calling timeKillEvent\n");
-		timeKillEvent(handle->TimerHandle);
+		DebugString("Disarming the VQ audio timer\n");
+		Host_Timer_Disarm(handle->TimerHandle);
 		handle->TimerHandle = 0;
-
-		DebugString("Calling timeEndPeriod\n");
-		timeEndPeriod(1000/VQA_TIMETICKS);
 
 		handle->Used = false;
 
@@ -535,7 +529,7 @@ long __cdecl Stop_Audio_Handler(VQAHandleP *vqap)
 *     NONE
 *
 ****************************************************************************/
-void CALLBACK AudioCallback ( UINT uTimerID, UINT, DWORD dwUser, DWORD, DWORD )
+void AudioCallback(uint32_t timer, void * user)
 {
 	Ahandle  	*audio;
 	DWORD			play_cursor;		//Position that direct sound is reading from
@@ -544,8 +538,8 @@ void CALLBACK AudioCallback ( UINT uTimerID, UINT, DWORD dwUser, DWORD, DWORD )
 	bool			buffer_stopped = false;
 	DWORD			status;
 
-	VQAHandle *vqa = (VQAHandle *)dwUser;
-	VQAHandleP *vqap = (VQAHandleP *)dwUser;
+	VQAHandle *vqa = (VQAHandle *)user;
+	VQAHandleP *vqap = (VQAHandleP *)user;
 
 	audio = &_handles[vqap->AudioHandleIndex];
 
@@ -556,7 +550,7 @@ void CALLBACK AudioCallback ( UINT uTimerID, UINT, DWORD dwUser, DWORD, DWORD )
 
 	EnterCriticalSection(&audio->CriticalSection);
 
-	if (!audio->SecondaryBufferPtr || audio->TimerHandle != uTimerID)  {
+	if (!audio->SecondaryBufferPtr || audio->TimerHandle != timer)  {
 		LeaveCriticalSection(&audio->CriticalSection);
 		InterlockedDecrement(&audio->SuspendAudioCallback);
 		return;

--- a/code/ahandle.h
+++ b/code/ahandle.h
@@ -15,6 +15,8 @@
 
 #include "vqaplay.h"
 
+#include <cstdint>
+
 #include <dsound.h>
 #include <windows.h>
 
@@ -56,7 +58,7 @@ struct Ahandle {
 	BOOL AudioBufInUse[MAX_BUFFERS];
 	void * AudioBuf[MAX_BUFFERS];
 	unsigned long AudioBufSize[MAX_BUFFERS];
-	UINT TimerHandle;
+	uint32_t TimerHandle;
 	DSBUFFERDESC BufferDesc;
 	WAVEFORMATEX DsBuffFormat;
 	LPDIRECTSOUNDBUFFER SecondaryBufferPtr;

--- a/code/dsaudio.cpp
+++ b/code/dsaudio.cpp
@@ -19,6 +19,7 @@
 #include "data.h"
 #include "dbgprint.h"
 #include "globals.h" // for GameInFocus
+#include "hosttimer.h"
 #include "language\language.h"
 #include "soscomp.h"
 #include "winfix.h"
@@ -177,7 +178,6 @@ DSAudio::DSAudio(void)
 	PrimaryBufferPtr = NULL;
 	SoundTimerHandle = NULL;
 
-	TimerResolution = 0;
 
 	PrimaryBufferDesc = new DSBUFFERDESC;
 	memset(PrimaryBufferDesc, 0, sizeof(*PrimaryBufferDesc));
@@ -444,23 +444,12 @@ bool DSAudio::Init( HWND window , int bits_per_sample, bool stereo , int rate )
 		*/
 		//InitializeCriticalSection(&GlobalAudioCriticalSection);
 
-		TIMECAPS tc;
-		if (timeGetDevCaps(&tc, sizeof(tc)) != TIMERR_NOERROR) {
-			DebugString("Error - Failed to obtain timer resolution caps\n");
-			TimerResolution = TIMER_WORST_RESOLUTION;
-		} else {
-			TimerResolution = std::min(std::max(tc.wPeriodMin, (unsigned int)TIMER_TARGET_RESOLUTION), tc.wPeriodMax);
-		}
-
-		DebugString("Audio timer resolution is %d milliseconds\n", TimerResolution);
-
-		timeBeginPeriod(TimerResolution);
-
 		/*
-		**	Initialise the Windows timer system to provide us with a callback
-		**
+		**	Arm the maintenance callback. The timer holds whatever resolution it needs for
+		**	as long as it is armed, and its disarm waits for a callback in flight, so
+		**	there is neither a resolution to negotiate nor a race to guard here.
 		*/
-		SoundTimerHandle = timeSetEvent ( 1000/MAINTENANCE_RATE , 1 , Sound_Timer_Callback , 0 , TIME_PERIODIC | TIME_KILL_SYNCHRONOUS);
+		SoundTimerHandle = Host_Timer_Arm(1000/MAINTENANCE_RATE, Sound_Timer_Callback, nullptr);
 		AudioDone = FALSE;
 		//_beginthread(&Sound_Thread, NULL, 16*1024, NULL);
 
@@ -529,9 +518,8 @@ void DSAudio::End(void)
 	**	Remove the Windows timer event we installed for the sound callback
 	*/
 	if (SoundTimerHandle){
-		timeKillEvent(SoundTimerHandle);
+		Host_Timer_Disarm(SoundTimerHandle);
 		SoundTimerHandle = 0;
-		timeEndPeriod(TimerResolution);
 	}
 
 	if (SoundObject && PrimaryBufferPtr){
@@ -1426,7 +1414,7 @@ void DSAudio::Unlock_Mutex(void)
  *    11/2/95 4:01PM ST : Created                                                              *
  *=============================================================================================*/
 
-void CALLBACK DSAudio::Sound_Timer_Callback ( UINT, UINT, DWORD, DWORD, DWORD )
+void DSAudio::Sound_Timer_Callback(uint32_t, void *)
 {
 	HANDLE mutex = Audio.TimerMutex;
 	if (WaitForSingleObject(mutex, 0) == 0) {

--- a/code/dsaudio.h
+++ b/code/dsaudio.h
@@ -16,6 +16,8 @@
 #include "audio.h"
 #include "soundint.h"
 
+#include <cstdint>
+
 #include <dsound.h>
 
 #define INVALID_SAMPLE_HANDLE -1
@@ -88,7 +90,7 @@ class DSAudio
 		bool Lock_Global_Mutex(void);
 		void Unlock_Global_Mutex(void);
 
-		static void CALLBACK Sound_Timer_Callback(UINT, UINT, DWORD, DWORD, DWORD);
+		static void Sound_Timer_Callback(uint32_t timer, void * user);
 		int Stream_Sample_Vol(void *buffer, int size, bool (*callback)(short, short int *, void **, int *), int volume, int handle);
 		void File_Stream_Preload(int handle);
 		static bool File_Callback(short int id, short int *odd, void **buffer, int *size);
@@ -184,13 +186,12 @@ class DSAudio
 		/*
 		**	Windows Handle for sound timer
 		*/
-		UINT SoundTimerHandle;
+		uint32_t SoundTimerHandle;
 
 		/*
 		 * This is the multimedia timer period, expressed in milliseconds, that the audio
 		 * system asks Windows for. It is clamped to what the timer device can provide.
 		 */
-		unsigned int TimerResolution;
 
 		/*
 		 * If the audio system has been shut down, then this flag will be true. Every entry

--- a/code/hosttimer.cpp
+++ b/code/hosttimer.cpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *                                O P E N  T S
+ *******************************************************************************
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 OpenTS contributors
+ *
+ * See LICENSE.md for applicable additional terms and warranty disclaimers.
+ ******************************************************************************/
+
+// The Windows side of hosttimer.h, over the multimedia timer.
+
+#ifdef _WIN32
+
+#include "always.h"
+
+#include "hosttimer.h"
+
+#include "win.h"
+
+
+// The multimedia timer calls back on a thread of its own, and its accuracy follows the
+// timer resolution in force, so the finest one is held for as long as a timer is armed.
+// TIME_KILL_SYNCHRONOUS is what makes the disarm hosttimer.h promises: without it
+// timeKillEvent returns while a callback may still be running. timeSetEvent wants a
+// callback shape of its own, so each armed timer carries the portable one it stands for,
+// and the resolution is released on the failure path as well as the ordinary one.
+namespace {
+
+struct ArmedTimerType
+{
+	MMRESULT Id;
+	HostTimerCallbackType Callback;
+	void * User;
+};
+
+ArmedTimerType _ArmedTimers[8];
+
+
+void CALLBACK Deliver(UINT id, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR)
+{
+	for (ArmedTimerType const & armed : _ArmedTimers) {
+		if (armed.Id == id && armed.Callback != nullptr) {
+			armed.Callback((uint32_t)armed.Id, armed.User);
+			return;
+		}
+	}
+}
+
+}
+
+
+uint32_t Host_Timer_Arm(uint32_t period, HostTimerCallbackType callback, void * user)
+{
+	if (callback == nullptr || period == 0) {
+		return(0);
+	}
+
+	for (ArmedTimerType & armed : _ArmedTimers) {
+		if (armed.Id != 0) continue;
+
+		armed.Callback = callback;
+		armed.User = user;
+
+		timeBeginPeriod(1);
+		armed.Id = timeSetEvent((UINT)period, 1, Deliver, 0, TIME_PERIODIC | TIME_KILL_SYNCHRONOUS);
+
+		if (armed.Id == 0) {
+			timeEndPeriod(1);
+			armed.Callback = nullptr;
+			return(0);
+		}
+		return((uint32_t)armed.Id);
+	}
+
+	return(0);
+}
+
+
+void Host_Timer_Disarm(uint32_t timer)
+{
+	if (timer == 0) return;
+
+	for (ArmedTimerType & armed : _ArmedTimers) {
+		if (armed.Id != (MMRESULT)timer) continue;
+
+		timeKillEvent(armed.Id);
+		timeEndPeriod(1);
+		armed.Id = 0;
+		armed.Callback = nullptr;
+		return;
+	}
+}
+
+#endif

--- a/code/hosttimer.h
+++ b/code/hosttimer.h
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *                                O P E N  T S
+ *******************************************************************************
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 OpenTS contributors
+ *
+ * See LICENSE.md for applicable additional terms and warranty disclaimers.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+// The routine a host timer runs, handed its own handle and the value it was armed with.
+// The handle lets a callback tell its own delivery from one left over from a timer that
+// has since been disarmed.
+using HostTimerCallbackType = void (*)(uint32_t timer, void * user);
+
+/*
+ * Arms a callback to run every period milliseconds until it is disarmed, and answers with
+ * a handle for it. Zero means the host would not arm one.
+ *
+ * The callback may arrive on a thread of the host's own, so it has to be safe to run while
+ * the engine thread is somewhere else. A host with no thread to spare delivers it from
+ * inside Host_Wait instead, which is the other half of the same contract: a caller that
+ * never waits never gets a callback.
+ */
+uint32_t Host_Timer_Arm(uint32_t period, HostTimerCallbackType callback, void * user);
+
+/*
+ * Disarms a timer, and does not return while a callback of its own is still running. That
+ * is what lets a caller tear down state the callback reads without racing it. The one
+ * exception is a callback disarming its own timer, which is allowed and returns at once.
+ */
+void Host_Timer_Disarm(uint32_t timer);


### PR DESCRIPTION
The VQA audio refill and the sound maintenance pass are armed through `Host_Timer_Arm`/`Host_Timer_Disarm` rather than `timeSetEvent` directly. `hosttimer.cpp` is the
Windows implementation and keeps `TIME_KILL_SYNCHRONOUS`. `hosttimer.h` states the contract without naming a platform, so another host can supply its own implementation later.

`dsaudio.cpp` loses the `timeGetDevCaps` negotiation and its `TimerResolution` member, since the timer holds its own resolution while armed. That also closes an unbalanced request in both callers, which released it only when arming succeeded.