### PR TITLE
Use forward slashes in language include paths

### DIFF
--- a/code/addon.cpp
+++ b/code/addon.cpp
@@ -14,7 +14,7 @@
 #include "ccfile.h"
 #include "data.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "ownrdraw.h"
 
 BOOL CALLBACK Select_Game_Type_Dialog_Proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam);

--- a/code/chat.cpp
+++ b/code/chat.cpp
@@ -19,7 +19,7 @@
 #include "globals.h"
 #include "house.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "rules.h"
 #include "session.h"
 #include "stimer.h"

--- a/code/conquer.cpp
+++ b/code/conquer.cpp
@@ -89,7 +89,7 @@
 #include "init.h"
 #include "ipxmgr.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "logic.h"
 #include "mainloop.h"
 #include "movie.h"

--- a/code/credits.cpp
+++ b/code/credits.cpp
@@ -46,7 +46,7 @@
 #include "dsurface.h"
 #include "globals.h"
 #include "house.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "rules.h"
 #include "scenario.h"
 #include "scheme.h"

--- a/code/display.cpp
+++ b/code/display.cpp
@@ -124,7 +124,7 @@
 #include "inline.h"
 #include "isotype.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "logic.h"
 #include "mixfile.h"
 #include "overtype.h"

--- a/code/dropship.cpp
+++ b/code/dropship.cpp
@@ -33,7 +33,7 @@
 #include "house.h"
 #include "infatype.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "misc.h"
 #include "mixfile.h"
 #include "mouse.h"

--- a/code/dsaudio.cpp
+++ b/code/dsaudio.cpp
@@ -19,7 +19,7 @@
 #include "data.h"
 #include "dbgprint.h"
 #include "globals.h" // for GameInFocus
-#include "language\language.h"
+#include "language/language.h"
 #include "soscomp.h"
 #include "winfix.h"
 

--- a/code/egos.cpp
+++ b/code/egos.cpp
@@ -54,7 +54,7 @@
 #include "globals.h"
 #include "goptions.h"
 #include "gscreen.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "misc.h"
 #include "ownrdraw.h"
 #include "scheme.h"

--- a/code/event.cpp
+++ b/code/event.cpp
@@ -58,7 +58,7 @@
 #include "foot.h"
 #include "goptions.h"
 #include "house.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mouse.h"
 #include "netsemantic.h"
 #include "rules.h"

--- a/code/gamedlg.cpp
+++ b/code/gamedlg.cpp
@@ -43,7 +43,7 @@
 #include "dsaudio.h"
 #include "globals.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "ownrdraw.h"
 #include "queue.h"
 #include "session.h"

--- a/code/goptions.cpp
+++ b/code/goptions.cpp
@@ -40,7 +40,7 @@
 #include "data.h"
 #include "dbgprint.h"
 #include "gamedlg.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "loaddlg.h"
 #include "ownrdraw.h"
 #include "queue.h"

--- a/code/house.cpp
+++ b/code/house.cpp
@@ -159,7 +159,7 @@
 #include "infatype.h"
 #include "inline.h"
 #include "ion.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lightcon.h"
 #include "logic.h"
 #include "mono.h"

--- a/code/infantry.cpp
+++ b/code/infantry.cpp
@@ -113,7 +113,7 @@
 #include "inline.h"
 #include "ion.h"
 #include "isotype.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lightcon.h"
 #include "mixfile.h"
 #include "mono.h"

--- a/code/init.cpp
+++ b/code/init.cpp
@@ -121,7 +121,7 @@
 #include "ionblast.h"
 #include "ipxmgr.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "laser.h"
 #include "light.h"
 #include "lightcon.h"

--- a/code/ion.cpp
+++ b/code/ion.cpp
@@ -30,7 +30,7 @@
 #include "globals.h"
 #include "gscreen.h"
 #include "house.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "laser.h"
 #include "lightcon.h"
 #include "mixfile.h"

--- a/code/list.cpp
+++ b/code/list.cpp
@@ -63,7 +63,7 @@
 #include "dialog.h"
 #include "dsurface.h"
 #include "font.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "scheme.h"
 #include "vector.h"
 #include "wwmouse.h"

--- a/code/loaddlg.cpp
+++ b/code/loaddlg.cpp
@@ -48,7 +48,7 @@
 #include "globals.h"
 #include "houstype.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "msgbox.h"
 #include "ownrdraw.h"
 #include "saveload.h"

--- a/code/mainloop.cpp
+++ b/code/mainloop.cpp
@@ -38,7 +38,7 @@
 #include "globals.h"
 #include "goptions.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "logic.h"
 #include "misc.h"
 #include "mpscore.h"

--- a/code/mainopt.cpp
+++ b/code/mainopt.cpp
@@ -23,7 +23,7 @@
 #include "gamedlg.h"
 #include "globals.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "misc.h"
 #include "video.h"
 #include "mixfile.h"

--- a/code/mapgen.cpp
+++ b/code/mapgen.cpp
@@ -38,7 +38,7 @@
 #include "init.h"
 #include "inline.h"
 #include "isotype.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "netshare.h"
 #include "nodes.h"
 #include "overtype.h"

--- a/code/mpscore.cpp
+++ b/code/mpscore.cpp
@@ -27,7 +27,7 @@
 #include "houstype.h"
 #include "incdec.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "msanim.h"
 #include "msengine.h"
 #include "msfont.h"

--- a/code/msgbox.h
+++ b/code/msgbox.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include "language\language.h"
+#include "language/language.h"
 #include "win.h"
 
 class WWMessageBox

--- a/code/netdlg.cpp
+++ b/code/netdlg.cpp
@@ -112,7 +112,7 @@
 #include "globals.h"
 #include "houstype.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "list.h"
 #include "queue.h"
 #include "rules.h"

--- a/code/netdlg2.cpp
+++ b/code/netdlg2.cpp
@@ -28,7 +28,7 @@
 #include "houstype.h"
 #include "init.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mapgen.h"
 #include "mplayer.h"
 #include "msgbox.h"

--- a/code/netshare.cpp
+++ b/code/netshare.cpp
@@ -18,7 +18,7 @@
 #include "globals.h"
 #include "goptions.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lzopipe.h"
 #include "lzostraw.h"
 #include "mapgen.h"

--- a/code/options.cpp
+++ b/code/options.cpp
@@ -72,7 +72,7 @@
 #include "init.h"
 #include "ipxmgr.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mouse.h"
 #include "msgbox.h"
 #include "ownrdraw.h"

--- a/code/ownrdraw.cpp
+++ b/code/ownrdraw.cpp
@@ -28,7 +28,7 @@
 #include "goptions.h"
 #include "hsv.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mainloop.h"
 #include "misc.h"
 #include "msgroute.h"

--- a/code/power.cpp
+++ b/code/power.cpp
@@ -56,7 +56,7 @@
 #include "draw.h"
 #include "globals.h"
 #include "house.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mixfile.h"
 #include "savestream.h"
 #include "surface.h"

--- a/code/preview.cpp
+++ b/code/preview.cpp
@@ -19,7 +19,7 @@
 #include "cell.h"
 #include "dbgprint.h"
 #include "dsurface.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lzopipe.h"
 #include "lzostraw.h"
 #include "overtype.h"

--- a/code/progress.cpp
+++ b/code/progress.cpp
@@ -20,7 +20,7 @@
 #include "draw.h"
 #include "gscreen.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lightcon.h"
 #include "mixfile.h"
 #include "ownrdraw.h"

--- a/code/queue.cpp
+++ b/code/queue.cpp
@@ -118,7 +118,7 @@
 #include "infatype.h"
 #include "ipxmgr.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "light.h"
 #include "mainloop.h"
 #include "mono.h"

--- a/code/radar.cpp
+++ b/code/radar.cpp
@@ -92,7 +92,7 @@
 #include "infantry.h"
 #include "infatype.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lightcon.h"
 #include "mixfile.h"
 #include "movies.h"

--- a/code/restate.cpp
+++ b/code/restate.cpp
@@ -24,7 +24,7 @@
 #include "dbgprint.h"
 #include "globals.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "movie.h"
 #include "msanim.h"
 #include "msengine.h"

--- a/code/saveload.cpp
+++ b/code/saveload.cpp
@@ -82,7 +82,7 @@
 #include "infatype.h"
 #include "init.h"
 #include "ion.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "loaddlg.h"
 #include "light.h"
 #include "logic.h"

--- a/code/scenario.cpp
+++ b/code/scenario.cpp
@@ -107,7 +107,7 @@
 #include "ion.h"
 #include "ipxmgr.h"
 #include "isotype.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "light.h"
 #include "logic.h"
 #include "mainopt.h"

--- a/code/score.cpp
+++ b/code/score.cpp
@@ -61,7 +61,7 @@
 #include "goptions.h"
 #include "houstype.h"
 #include "keyboard.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "misc.h"
 #include "mixfile.h"
 #include "movie.h"

--- a/code/session.cpp
+++ b/code/session.cpp
@@ -59,7 +59,7 @@
 #include "gamedirs.h"		// for Search_Files.
 #include "globals.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "msgloop.h"
 #include "progress.h"
 #include "queue.h"

--- a/code/sidebar.cpp
+++ b/code/sidebar.cpp
@@ -99,7 +99,7 @@
 #include "goptions.h"
 #include "house.h"
 #include "incdec.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "map.h"
 #include "mixfile.h"
 #include "movie.h"

--- a/code/skirmish.cpp
+++ b/code/skirmish.cpp
@@ -17,7 +17,7 @@
 #include "goptions.h"
 #include "houstype.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mapgen.h"
 #include "mplayer.h"
 #include "msgbox.h"

--- a/code/sounddlg.cpp
+++ b/code/sounddlg.cpp
@@ -42,7 +42,7 @@
 #include "goptions.h"
 #include "incdec.h"
 #include "init.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "ownrdraw.h"
 #include "theme.h"
 #include "winfix.h"

--- a/code/spawner.cpp
+++ b/code/spawner.cpp
@@ -25,7 +25,7 @@
 #include "houstype.h"
 #include "init.h"
 #include "ipxmgr.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "loaddlg.h"
 #include "mplayer.h"
 #include "netshare.h"

--- a/code/startup.cpp
+++ b/code/startup.cpp
@@ -90,7 +90,7 @@
 #include "ipxmgr.h"
 #include "isotype.h"
 #include "jumpjet.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "levitate.h"
 #include "light.h"
 #include "lightcon.h"

--- a/code/super.cpp
+++ b/code/super.cpp
@@ -62,7 +62,7 @@
 #include "infatype.h"
 #include "inline.h"
 #include "ionblast.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mouse.h"
 #include "rules.h"
 #include "savestream.h"

--- a/code/tab.cpp
+++ b/code/tab.cpp
@@ -47,7 +47,7 @@
 #include "dialog.h"
 #include "draw.h"
 #include "goptions.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mixfile.h"
 #include "queue.h"
 #include "rules.h"

--- a/code/techno.cpp
+++ b/code/techno.cpp
@@ -169,7 +169,7 @@
 #include "ion.h"
 #include "isotile.h"
 #include "isotype.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "laser.h"
 #include "lightcon.h"
 #include "mono.h"

--- a/code/textbtn.cpp
+++ b/code/textbtn.cpp
@@ -45,7 +45,7 @@
 #include "data.h"
 #include "dialog.h"
 #include "font.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "lightcon.h"
 #include "scheme.h"
 #include "surface.h"

--- a/code/wdtconflict.cpp
+++ b/code/wdtconflict.cpp
@@ -10,7 +10,7 @@
 #include "always.h"
 
 #include "data.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "wdtnet.h"
 
 using namespace WorldDominationTour;

--- a/code/wdtgameoptions.cpp
+++ b/code/wdtgameoptions.cpp
@@ -10,7 +10,7 @@
 #include "always.h"
 
 #include "data.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "wdtnet.h"
 
 using namespace WorldDominationTour;

--- a/code/wdtprops.cpp
+++ b/code/wdtprops.cpp
@@ -10,7 +10,7 @@
 #include "always.h"
 
 #include "data.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "ownrdraw.h"
 #include "wdtnet.h"
 

--- a/code/wdtsel.cpp
+++ b/code/wdtsel.cpp
@@ -8,7 +8,7 @@
  ******************************************************************************/
 
 #include "always.h"
-#include "language\language.h"
+#include "language/language.h"
 
 #include "_keyboar.h"
 #include "_surface.h"

--- a/code/worlddom.cpp
+++ b/code/worlddom.cpp
@@ -15,7 +15,7 @@
 #include "_pk.h"
 #include "addon.h"
 #include "grphmenu.h"
-#include "language\language.h"
+#include "language/language.h"
 #include "mapgen.h"
 #include "mixfile.h"
 #include "ownrdraw.h"


### PR DESCRIPTION
This fixes some Windows-specific paths in `#include`s to make clang happy.