### PR TITLE
Drop MASM from the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(OpenTS VERSION 0.2.0 LANGUAGES C CXX ASM_MASM)
+project(OpenTS VERSION 0.2.0 LANGUAGES C CXX)
 
 # A SemVer prerelease label, which project() cannot carry because it takes numbers only. Set it
 # to "beta1" and the version reads 0.1.0-beta1; leave it empty outside a prerelease series. The

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -28,7 +28,6 @@ file(GLOB_RECURSE OPENTS_RAW CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.hh"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.rc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.asm"
 )
 
 #
@@ -108,11 +107,6 @@ set(OPENTS_COMPILE_OPTIONS
         $<$<COMPILE_LANGUAGE:C>:
             /Zi /Od /RTC1 $<$<C_COMPILER_ID:MSVC>:/MP> /Oy- /arch:SSE2 /fp:precise
         >
-
-        # ---------- MASM ----------
-        $<$<COMPILE_LANGUAGE:ASM_MASM>:
-            -Zi -c -coff -Cx -safeseh
-        >
     >
 
     # ================= RELEASE =================
@@ -128,11 +122,6 @@ set(OPENTS_COMPILE_OPTIONS
         # ---------- C ----------
         $<$<COMPILE_LANGUAGE:C>:
             /Zi /O2 /GF $<$<C_COMPILER_ID:MSVC>:/MP> /arch:SSE2 /fp:precise
-        >
-
-        # ---------- MASM ----------
-        $<$<COMPILE_LANGUAGE:ASM_MASM>:
-            -Zi -c -coff -Cx -safeseh
         >
     >
 )
@@ -207,16 +196,12 @@ message(STATUS "${PROJECT_NAME}: Applying linker options...")
 #  + all Win32 libs
 #
 
-# The bgfx targets are linked by file rather than by name. Their interface settings
-# include compiler switches and a directory of headers that shadow the system ones, and
-# the Visual Studio generator would hand all of that to ML.EXE as well, which fails.
-add_dependencies(OpenTS bgfx bx bimg)
 target_link_libraries(OpenTS PRIVATE
     VQALib
 
-    $<TARGET_FILE:bgfx>
-    $<TARGET_FILE:bx>
-    $<TARGET_FILE:bimg>
+    bgfx
+    bx
+    bimg
     comctl32
     dbghelp
     dsound
@@ -247,25 +232,6 @@ endif()
 
 #
 # ---------------------------------------------------------
-# MASM assembly support
-# ---------------------------------------------------------
-#
-message(STATUS "${PROJECT_NAME}: Adding MASM support...")
-
-enable_language(ASM_MASM)
-
-# Dash-form options assemble under both ML.EXE and the clang-cl toolchain's UASM.
-foreach(f ${OPENTS_SRC})
-    if(f MATCHES "\\.asm$")
-        set_source_files_properties(${f} PROPERTIES
-            LANGUAGE ASM_MASM
-            COMPILE_FLAGS "-Zi -c -coff -Cx"
-        )
-    endif()
-endforeach()
-
-#
-# ---------------------------------------------------------
 # Visual Studio source groups
 # ---------------------------------------------------------
 #
@@ -289,13 +255,6 @@ endforeach()
 foreach(f ${OPENTS_SRC})
     if(f MATCHES "\\.hh$")
         source_group("Header Files\\Define Header Files" FILES ${f})
-    endif()
-endforeach()
-
-# Assembly Files
-foreach(f ${OPENTS_SRC})
-    if(f MATCHES "\\.asm$")
-        source_group("Assembly Files" FILES ${f})
     endif()
 endforeach()
 


### PR DESCRIPTION
No documentation update: docs/BUILDING.md does not mention MASM, and this only removes now-unused build configuration.

