### PR TITLE
Replace hardcoded AhandleInitParams size with sizeof in Open_Audio_Handler

### DIFF
--- a/code/ahandle.cpp
+++ b/code/ahandle.cpp
@@ -207,7 +207,7 @@ long __cdecl Open_Audio_Handler(VQAHandleP *vqap, AhandleInitParams *params, lon
 		index++;
 	}
 
-	if (index != 1 && b == 16) {
+	if (index != 1 && b == sizeof(AhandleInitParams)) {
 
 		VQAConfig *config = &vqap->Config;
 


### PR DESCRIPTION
The struct contains a pointer, so this check fails on non 32-bit architectures.