### PR TITLE
Drop UASM dependency from clang-cl toolchain

### DIFF
--- a/cmake/toolchains/clang-cl-msvc.cmake
+++ b/cmake/toolchains/clang-cl-msvc.cmake
@@ -69,7 +69,6 @@ find_program(_opents_lld_link lld-link REQUIRED)
 find_program(_opents_llvm_lib llvm-lib REQUIRED)
 find_program(_opents_llvm_mt llvm-mt REQUIRED)
 find_program(_opents_llvm_rc llvm-rc REQUIRED)
-find_program(_opents_uasm uasm REQUIRED)
 
 set(CMAKE_C_COMPILER "${_opents_clang_cl}")
 set(CMAKE_CXX_COMPILER "${_opents_clang_cl}")
@@ -83,7 +82,6 @@ set(CMAKE_LINKER "${_opents_lld_link}")
 set(CMAKE_AR "${_opents_llvm_lib}")
 set(CMAKE_RC_COMPILER "${_opents_llvm_rc}" CACHE FILEPATH "" FORCE)
 set(CMAKE_MT "${_opents_llvm_mt}")
-set(CMAKE_ASM_MASM_COMPILER "${_opents_uasm}" CACHE FILEPATH "" FORCE)
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE
     "${CMAKE_CURRENT_LIST_DIR}/clang-cl-rc-rules.cmake")

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -69,7 +69,7 @@ intermediates stay in the selected build directory.
 ## Experimental clang-cl cross-build
 
 An unsupported Linux cross-build is available for compiler-portability work. It
-uses native `clang-cl`, LLD, LLVM library and resource tools, and UASM with the
+uses native `clang-cl`, LLD, and LLVM library and resource tools with the
 MSVC headers and libraries. It does not expand the supported build matrix or
 establish runtime behavior.
 
@@ -89,8 +89,8 @@ cmake -S . -B build/clang-cl -G Ninja \
 cmake --build build/clang-cl
 ```
 
-The toolchain requires `clang-cl`, `lld-link`, `llvm-lib`, `llvm-mt`, `llvm-rc`,
-and `uasm` on `PATH`. It exports `compile_commands.json`; one configuration in
+The toolchain requires `clang-cl`, `lld-link`, `llvm-lib`, `llvm-mt`, and
+`llvm-rc` on `PATH`. It exports `compile_commands.json`; one configuration in
 `.vscode/c_cpp_properties.clang.example.json` reads that file for IntelliSense.
 
 ## Build from Visual Studio Code


### PR DESCRIPTION
Following drop of MASM in #123 from the list of dependencies, it is also worth drop UASM from the clang-cl toolchain