### PR TITLE
Keep paused radar movie frames visible

### DIFF
--- a/code/movies.cpp
+++ b/code/movies.cpp
@@ -290,6 +290,22 @@ bool Movie_Advance_Frame(VQHandle * handle, bool &finished)
 
 
 /// <summary>
+/// Redraws the current frame of a paused movie.
+/// </summary>
+/// <returns>bool; Was the paused frame redrawn?</returns>
+bool Movie_Redraw_Paused_Frame(VQHandle * handle)
+{
+	if (CurrentVQ != NULL) {
+		return(false);
+	}
+	CurrentVQ = handle;
+	bool res = handle->VQA->Redraw_Paused_Frame();
+	CurrentVQ = NULL;
+	return(res);
+}
+
+
+/// <summary>
 /// Determines if a movie currently owns the screen.
 /// </summary>
 /// <returns>bool; Is a movie playing at the moment?</returns>

--- a/code/movies.h
+++ b/code/movies.h
@@ -25,6 +25,7 @@ VQHandle * Movie_Create(char const * name, Surface * surface, Rect rect1, Rect r
 void Movie_Destroy(VQHandle * handle);
 void Movie_Play(VQHandle *movie, bool hide_mouse, ThemeType theme, bool user_break_not_allowed);
 bool Movie_Advance_Frame(VQHandle * handle, bool &finished);
+bool Movie_Redraw_Paused_Frame(VQHandle * handle);
 bool Movie_Is_Playing(void);
 void Movie_Pause(VQHandle * handle);
 void Movie_Resume(VQHandle * handle);

--- a/code/radar.cpp
+++ b/code/radar.cpp
@@ -2267,14 +2267,20 @@ void RadarClass::Play_Movie(void)
 		needs_volume_adjustment = false;
 	}
 
+	if (IngameVQ.Count() > 0) {
+		handle = IngameVQ[0];
+	}
+
 	if (FullRedraw == true) {
 		Draw_Shape(*SidebarSurface, *SidebarDrawer, (ShapeSet const *)RadarAnim, MAX_RADAR_FRAMES, Point2D(RadX, RadY), SidebarSurface->Get_Rect());
+		if (handle != NULL && handle->IsInitialized == true && handle->VQA->Is_Paused()) {
+			Movie_Redraw_Paused_Frame(handle);
+		}
 		LastDrawRect = Rect(RadX, RadY, RadWidth, RadHeight);
 		DebugString("Radar: Movie full redrawn\n");
 	}
 
 	if (!needs_volume_adjustment && IngameVQ.Count() > 0) {
-		handle = IngameVQ[0];
 		if (handle != NULL && handle->IsInitialized == true) {
 			if (!handle->VQA->Is_Paused()) {
 				if (Movie_Advance_Frame(handle, needs_volume_adjustment) == true) {

--- a/code/vqa.cpp
+++ b/code/vqa.cpp
@@ -672,6 +672,23 @@ bool VQAClass::Advance_Frame(bool & finished)
 }
 
 
+bool VQAClass::Redraw_Paused_Frame(void)
+{
+	if (!IsOpen || !IsPaused) {
+		return(false);
+	}
+
+	int res = VQA_Play(Handle, VQAMODE_PAUSE, VQAPLAYF_REPAINT);
+	if (res < VQAERR_OK) {
+		return(false);
+	}
+	if (SurfaceDrawCallback) {
+		SurfaceDrawCallback();
+	}
+	return(true);
+}
+
+
 /***************************************************************************
  * Pause_VQA - Pauses a VQA in order to freeze the VQA timers.             *
  *                                                                         *

--- a/code/vqa.h
+++ b/code/vqa.h
@@ -127,6 +127,7 @@ class VQAClass
 		int Play_VQA(int last_frame_to_play, bool breakout);
 		void Play_VQA_Frame(int frame_number);
 		bool Advance_Frame(bool &);
+		bool Redraw_Paused_Frame(void);
 		void Pause_VQA(void);
 		void Resume_VQA(void);
 		void Close_And_Free_VQA(void);

--- a/manual/changes/radar-movie-pause-frame.md
+++ b/manual/changes/radar-movie-pause-frame.md
@@ -1,0 +1,13 @@
+---
+title: Keep the last radar movie frame visible while paused
+category: fix
+release: 0.2.0
+targets:
+  - type: format
+    id: vqa
+    effect: changed
+credit:
+  - Belonit
+---
+
+Paused in-game movies now remain visible in the radar pane. Playback resumes from the same frame when the game is unpaused.


### PR DESCRIPTION
Paused in-game movies now remain visible in the radar pane. Playback resumes from the same frame when the game is unpaused.