### PR TITLE
Take a passenger's direction from ObjectClass::Direction

### DIFF
--- a/code/unit.cpp
+++ b/code/unit.cpp
@@ -4471,8 +4471,7 @@ FacingType UnitClass::Desired_Load_Dir(ObjectClass * passenger, Cell & moveto) c
 	FacingType face = FACING_N;
 	FacingType faceto;
 	if (passenger != NULL) {
-		DirType direction = direction.Direction(Center_Coord(), passenger->Center_Coord());
-		faceto = (FacingType)direction.As_Dir256();
+		faceto = (FacingType)Direction(passenger).As_Dir256();
 	} else {
 		faceto = (FacingType)(PrimaryFacing.Current().Right_180()).As_Dir256();
 	}


### PR DESCRIPTION
This fixes a warning about undefined behavior:

```
  unit.cpp:4474:23: warning: variable 'direction' is uninitialized when used within its own
  initialization [-Wuninitialized]
   4474 |   DirType direction = direction.Direction(Center_Coord(), passenger->Center_Coord());
        |           ~~~~~~~~~   ^~~~~~~~~
```

(I should mention that this was when building with clang.)