### PR TITLE
Fix invalid object formatting in mono debug output

### DIFF
--- a/code/house.cpp
+++ b/code/house.cpp
@@ -766,7 +766,7 @@ void HouseClass::Debug_Dump(MonoClass * mono) const
 
 	mono->Set_Cursor(10, 5);mono->Printf("%8.8s", (BuildStructure == STRUCT_NONE) ? " " : BuildingTypes[BuildStructure]->Graphic_Name());
 	mono->Set_Cursor(21, 5);mono->Printf("%3d", CurBuildings);
-	mono->Set_Cursor(27, 5);mono->Printf("%8d", Tiberium);
+	mono->Set_Cursor(27, 5);mono->Printf("%8d", Tiberium.Get_Total_Amount());
 	mono->Set_Cursor(37, 5);mono->Printf("%5d", Drain);
 	mono->Set_Cursor(44, 5);mono->Printf("%16.16s", Name_From_Quarry(PreferredTarget));
 	mono->Set_Cursor(62, 5);mono->Printf("%5d", (int)TriggerTime);

--- a/code/techno.cpp
+++ b/code/techno.cpp
@@ -712,7 +712,7 @@ void TechnoClass::Debug_Dump(MonoClass * mono) const
 		mono->Set_Cursor(69, 5);mono->Printf("%08X", ArchiveTarget);
 	}
 	mono->Set_Cursor(47, 3);mono->Printf("%02X:%02X", PrimaryFacing.Current(), PrimaryFacing.Desired());
-	mono->Set_Cursor(64, 1);mono->Printf("%d(%d)", Cloak, CloakingDevice);
+	mono->Set_Cursor(64, 1);mono->Printf("%d(%d)", Cloak, CloakingDevice.Fetch_Stage());
 
 	mono->Fill_Attrib(14, 15, 12, 1, IsUseless ? MonoClass::INVERSE : MonoClass::NORMAL);
 	mono->Fill_Attrib(14, 16, 12, 1, IsTickedOff ? MonoClass::INVERSE : MonoClass::NORMAL);


### PR DESCRIPTION
Fixes debug output for Tiberium and CloakingDevice by passing their numeric values to %d instead of the objects themselves. This removes undefined behavior and fixes Clang Debug builds.