### PR TITLE
Poll the network socket from the service pass

### DIFF
--- a/code/ipxmgr.cpp
+++ b/code/ipxmgr.cpp
@@ -996,6 +996,8 @@ int IPXManagerClass::Service(void)
 
 	if ( PacketTransport ) {
 
+		PacketTransport->Service();
+
 		do {
 			temp_receive_buffer_len = sizeof (temp_receive_buffer);
 			temp_address_len = sizeof (temp_address);

--- a/code/winstub.cpp
+++ b/code/winstub.cpp
@@ -73,7 +73,6 @@
 #include "wincursor.h"
 #include "windlg.h"
 #include "winfix.h"
-#include "wsproto.h"
 #include "wwmouse.h"
 #include "mainopt.h"
 #include "conquer.h"
@@ -189,19 +188,6 @@ LRESULT CALLBACK /*_export*/ Windows_Procedure(HWND hwnd, UINT message, UINT wPa
 	}
 
 	int	low_param = LOWORD(wParam);
-
-	/*
-	**	Pass on any messages intended for the winsock message handler.
-	*/
-	if ( PacketTransport ) {
-		if ( message == (UINT) PacketTransport->Protocol_Event_Message() ) {
-			if ( PacketTransport->Message_Handler (hwnd, message, wParam, lParam) ){
-				return( DefWindowProc (hwnd, message, wParam, lParam) );
-			}else{
-				return(0);
-			}
-		}
-	}
 
 	Map.Message_Handler(hwnd, message, wParam, lParam);
 

--- a/code/wsproto.cpp
+++ b/code/wsproto.cpp
@@ -54,10 +54,8 @@
 
 #include "wsproto.h"
 
-#include "_keyboar.h"
 #include "dbgprint.h"
 #include "globals.h"
-#include "keyboard.h"
 #include "netadmit.h"
 #include "vector.h"
 
@@ -98,11 +96,10 @@ char const * Packet_Drop_Name(WinsockInterfaceClass::PacketDropReasonType reason
  *    3/20/96 2:51PM ST : Created                                                              *
  *=============================================================================================*/
 WinsockInterfaceClass::WinsockInterfaceClass(void) :
-ASync(INVALID_HANDLE_VALUE),
-Socket(INVALID_SOCKET)
+Socket(INVALID_SOCKET),
+Listening(false)
 {
 	WinsockInitialised = false;
-	ASync = INVALID_HANDLE_VALUE;
 	Socket = INVALID_SOCKET;
 
 	for (int i = 0; i < WS_MAX_STATIC_BUFFERS; i++) {
@@ -166,9 +163,6 @@ void WinsockInterfaceClass::Close(void)
 	*/
 	if (!WinsockInitialised) return;
 
-	/*
-	**	Cancel any outstaning asyncronous events
-	*/
 	Stop_Listening();
 
 	/*
@@ -224,16 +218,13 @@ void WinsockInterfaceClass::Close_Socket (void)
  *=============================================================================================*/
 bool WinsockInterfaceClass::Start_Listening (void)
 {
-	/*
-	**	Enable asynchronous events on the socket
-	*/
-	if ( WSAAsyncSelect ( Socket, MainWindow, Protocol_Event_Message(), FD_READ | FD_WRITE) == SOCKET_ERROR ){
-		DebugString ( "Async select failed.\n" );
+	unsigned long nonblocking = 1;
+	if ( ioctlsocket ( Socket, FIONBIO, &nonblocking ) == SOCKET_ERROR ) {
+		DebugString ( "Failed to make the socket non-blocking - error code %d.\n", LAST_ERROR );
 		assert (false);
-		WSACancelAsyncRequest(ASync);
-		ASync = INVALID_HANDLE_VALUE;
 		return(false);
 	}
+	Listening = true;
 	return(true);
 }
 
@@ -254,10 +245,20 @@ bool WinsockInterfaceClass::Start_Listening (void)
  *=============================================================================================*/
 void WinsockInterfaceClass::Stop_Listening (void)
 {
-	if ( ASync != INVALID_HANDLE_VALUE ) {
-		WSACancelAsyncRequest ( ASync );
-		ASync = INVALID_HANDLE_VALUE;
-	}
+	Listening = false;
+}
+
+
+/// <summary>
+/// Moves pending packets between the socket and the holding buffers, so
+/// that Read finds what has arrived and what WriteTo queued has gone out.
+/// </summary>
+void WinsockInterfaceClass::Service(void)
+{
+	if (!Listening) return;
+
+	Receive_Pending();
+	Send_Pending();
 }
 
 
@@ -363,10 +364,9 @@ bool WinsockInterfaceClass::Init(void)
 	WSADATA *winsock_info = (WSADATA*) (&buffer[0]);
 
 	/*
-	**	Initialise socket and event handle to null
+	**	Initialise socket to null
 	*/
 	Socket =INVALID_SOCKET;
-	ASync = INVALID_HANDLE_VALUE;
 	Discard_In_Buffers();
 	Discard_Out_Buffers();
 
@@ -593,11 +593,6 @@ void *WinsockInterfaceClass::Get_New_In_Buffer(void)
 int WinsockInterfaceClass::Read(void *buffer, int &buffer_len, void *address, int &address_len)
 {
 	/*
-	**	Call the message loop in case there are any outstanding winsock READ messages.
-	*/
-	Keyboard->Check();
-
-	/*
 	**	If there are no available packets then return 0
 	*/
 	if ( InBuffers.Count() == 0 ) return(0);
@@ -710,15 +705,7 @@ void WinsockInterfaceClass::WriteTo(void *buffer, int buffer_len, void *address,
 	*/
 	OutBuffers.Add ( packet );
 
-	/*
-	**	Send a message to ourselves so that we can initiate a write if Winsock is idle.
-	*/
-	SendMessage ( MainWindow, Protocol_Event_Message(), 0, (LONG)FD_WRITE );
-
-	/*
-	**	Make sure the message loop gets called.
-	*/
-	Keyboard->Check();
+	Send_Pending();
 }
 
 
@@ -770,15 +757,7 @@ void WinsockInterfaceClass::Broadcast (void *buffer, int buffer_len)
 	*/
 	OutBuffers.Add ( packet );
 
-	/*
-	**	Send a message to ourselves so that we can initiate a write if Winsock is idle.
-	*/
-	SendMessage ( MainWindow, Protocol_Event_Message(), 0, (LONG)FD_WRITE );
-
-	/*
-	**	Make sure the message loop gets called.
-	*/
-	Keyboard->Check();
+	Send_Pending();
 }
 
 

--- a/code/wsproto.cpp
+++ b/code/wsproto.cpp
@@ -203,8 +203,8 @@ void WinsockInterfaceClass::Close_Socket (void)
 
 
 /// <summary>
-/// Puts the socket into non-blocking mode and lets Service poll it.
-/// Nothing is received until this succeeds.
+/// Puts the socket into non-blocking mode so Service can poll it. Nothing is
+/// received until this succeeds.
 /// </summary>
 /// <returns>bool; Is the socket ready to be polled?</returns>
 bool WinsockInterfaceClass::Start_Listening (void)

--- a/code/wsproto.cpp
+++ b/code/wsproto.cpp
@@ -202,20 +202,11 @@ void WinsockInterfaceClass::Close_Socket (void)
 }
 
 
-/***********************************************************************************************
- * WIC::Start_Listening -- Enable callbacks for read/write events on our socket                *
- *                                                                                             *
- *                                                                                             *
- *                                                                                             *
- * INPUT:    Nothing                                                                           *
- *                                                                                             *
- * OUTPUT:   Nothing                                                                           *
- *                                                                                             *
- * WARNINGS: None                                                                              *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *    8/5/97 11:54AM ST : Created                                                              *
- *=============================================================================================*/
+/// <summary>
+/// Puts the socket into non-blocking mode and lets Service poll it.
+/// Nothing is received until this succeeds.
+/// </summary>
+/// <returns>bool; Is the socket ready to be polled?</returns>
 bool WinsockInterfaceClass::Start_Listening (void)
 {
 	unsigned long nonblocking = 1;
@@ -229,20 +220,10 @@ bool WinsockInterfaceClass::Start_Listening (void)
 }
 
 
-/***********************************************************************************************
- * WIC::Stop_Listening -- Disable the winsock event callback                                   *
- *                                                                                             *
- *                                                                                             *
- *                                                                                             *
- * INPUT:    Nothing                                                                           *
- *                                                                                             *
- * OUTPUT:   Nothing                                                                           *
- *                                                                                             *
- * WARNINGS: None                                                                              *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *    8/5/97 12:06PM ST : Created                                                              *
- *=============================================================================================*/
+/// <summary>
+/// Stops Service polling the socket, leaving the socket itself open. WriteTo and
+/// Broadcast still send what they are given.
+/// </summary>
 void WinsockInterfaceClass::Stop_Listening (void)
 {
 	Listening = false;

--- a/code/wsproto.cpp
+++ b/code/wsproto.cpp
@@ -210,8 +210,8 @@ void WinsockInterfaceClass::Close_Socket (void)
 bool WinsockInterfaceClass::Start_Listening (void)
 {
 	unsigned long nonblocking = 1;
-	if ( ioctlsocket ( Socket, FIONBIO, &nonblocking ) == SOCKET_ERROR ) {
-		DebugString ( "Failed to make the socket non-blocking - error code %d.\n", LAST_ERROR );
+	if (ioctlsocket(Socket, FIONBIO, &nonblocking) == SOCKET_ERROR) {
+		DebugString("Failed to make the socket non-blocking - error code %d.\n", LAST_ERROR);
 		assert (false);
 		return(false);
 	}

--- a/code/wsproto.h
+++ b/code/wsproto.h
@@ -64,12 +64,6 @@
 #define PLANET_WESTWOOD_HANDLE_MAX 20	// Max length of a WChat handle
 
 /*
-**	Define events for Winsock callbacks
-*/
-#define WM_UDPASYNCEVENT		(WM_USER + 116)	// UDP socket Async event
-
-
-/*
 **	Enum to identify the protocols supported by the Winsock interface.
 */
 enum ProtocolEnum {
@@ -113,8 +107,14 @@ class WinsockInterfaceClass {
 		virtual void Discard_In_Buffers (void);
 		virtual void Discard_Out_Buffers (void);
 
+		// Only a listening transport moves packets in Service. The socket is
+		// made non-blocking, so a poll never waits on it.
 		virtual bool Start_Listening (void);
 		virtual void Stop_Listening (void);
+
+		// Takes every datagram the socket holds into the in buffers and sends
+		// what the out buffers hold. Call wherever the manager is serviced.
+		virtual void Service (void);
 
 		virtual void Clear_Socket_Error(SOCKET socket);
 
@@ -127,17 +127,9 @@ class WinsockInterfaceClass {
 			return(PROTOCOL_NONE);
 		};
 
-		virtual int Protocol_Event_Message (void) {
-			return(0);
-		};
-
 		virtual bool Open_Socket ( SOCKET ) {
 			return(false);
 		};
-
-		virtual int Message_Handler(HWND, UINT, UINT, LONG) {
-			return(1);
-		}
 
 		virtual bool Get_Host_Name(char *name, int len);
 
@@ -189,6 +181,12 @@ class WinsockInterfaceClass {
 		unsigned int Calculate_Packet_CRC(void const *buffer, int buffer_len) const;
 		void Record_Packet_Drop(PacketDropReasonType reason);
 
+		// Receive_Pending takes every datagram the socket holds into the in
+		// buffers. Send_Pending sends the out buffers until they are empty or
+		// the socket will take no more. A protocol supplies both.
+		virtual void Receive_Pending(void) {}
+		virtual void Send_Pending(void) {}
+
 		/*
 		**	Array of buffers to temporarily store incoming and outgoing packets.
 		*/
@@ -223,10 +221,8 @@ class WinsockInterfaceClass {
 		*/
 		SOCKET				Socket;
 
-		/*
-		**	Async object required for callbacks to our message handler.
-		*/
-		HANDLE				ASync;
+		// Whether Service may poll the socket.
+		bool				Listening;
 
 		/*
 		**	Temporary receive buffer to use when querying Winsock for incoming packets.

--- a/code/wsproto.h
+++ b/code/wsproto.h
@@ -107,13 +107,10 @@ class WinsockInterfaceClass {
 		virtual void Discard_In_Buffers (void);
 		virtual void Discard_Out_Buffers (void);
 
-		// Only a listening transport moves packets in Service. The socket is
-		// made non-blocking, so a poll never waits on it.
 		virtual bool Start_Listening (void);
 		virtual void Stop_Listening (void);
 
-		// Takes every datagram the socket holds into the in buffers and sends
-		// what the out buffers hold. Call wherever the manager is serviced.
+		// Call wherever the manager is serviced.
 		virtual void Service (void);
 
 		virtual void Clear_Socket_Error(SOCKET socket);
@@ -181,9 +178,7 @@ class WinsockInterfaceClass {
 		unsigned int Calculate_Packet_CRC(void const *buffer, int buffer_len) const;
 		void Record_Packet_Drop(PacketDropReasonType reason);
 
-		// Receive_Pending takes every datagram the socket holds into the in
-		// buffers. Send_Pending sends the out buffers until they are empty or
-		// the socket will take no more. A protocol supplies both.
+		// A protocol supplies both; a transport without one moves no packets.
 		virtual void Receive_Pending(void) {}
 		virtual void Send_Pending(void) {}
 

--- a/code/wsproto.h
+++ b/code/wsproto.h
@@ -111,7 +111,7 @@ class WinsockInterfaceClass {
 		virtual void Stop_Listening (void);
 
 		// Call wherever the manager is serviced.
-		virtual void Service (void);
+		virtual void Service(void);
 
 		virtual void Clear_Socket_Error(SOCKET socket);
 

--- a/code/wspudp.cpp
+++ b/code/wspudp.cpp
@@ -45,7 +45,6 @@
 
 #include "dbgprint.h"
 #include "misc.h"
-#include "msgloop.h"
 #include "netadmit.h"
 #include "vector.h"
 
@@ -173,7 +172,8 @@ int UDPInterfaceClass::Send_To(const char *buffer, int buffer_len, sockaddr_in *
 /// packet reports its sender by tunnel ID, since the server is the only endpoint the
 /// socket ever sees.
 /// </summary>
-/// <returns>The number of payload bytes received, or SOCKET_ERROR.</returns>
+/// <returns>The number of payload bytes received, RECEIVE_IGNORED for a datagram that
+/// was not for this client, or SOCKET_ERROR when the socket delivered nothing.</returns>
 int UDPInterfaceClass::Receive_From(char *buffer, int buffer_len, sockaddr_in *source)
 {
 	int address_len = sizeof(*source);
@@ -188,16 +188,16 @@ int UDPInterfaceClass::Receive_From(char *buffer, int buffer_len, sockaddr_in *s
 	if (rc == SOCKET_ERROR) return(SOCKET_ERROR);
 
 	unsigned short header[2];
-	if (rc < (int)sizeof(header)) return(SOCKET_ERROR);
+	if (rc < (int)sizeof(header)) return(RECEIVE_IGNORED);
 	std::memcpy(header, tunnelled, sizeof(header));
 
 	// Anything too short to carry a header, or addressed to somebody else, is not ours.
 	if (rc <= TUNNEL_HEADER_SIZE || header[1] != TunnelID) {
-		return(SOCKET_ERROR);
+		return(RECEIVE_IGNORED);
 	}
 
 	rc -= TUNNEL_HEADER_SIZE;
-	if (rc > buffer_len) return(SOCKET_ERROR);
+	if (rc > buffer_len) return(RECEIVE_IGNORED);
 
 	std::memcpy(buffer, tunnelled + TUNNEL_HEADER_SIZE, rc);
 
@@ -500,190 +500,125 @@ void UDPInterfaceClass::Broadcast (void *buffer, int buffer_len)
 		*/
 		OutBuffers.Add ( packet );
 
-		/*
-		**	Send a message to ourselves so that we can initiate a write if Winsock is idle.
-		*/
-		SendMessage ( MainWindow, Protocol_Event_Message(), 0, (LONG)FD_WRITE );
-
-		/*
-		**	Make sure the message loop gets called.
-		*/
-		Windows_Message_Handler();
+		Send_Pending();
 	}
 }
 
 
-/***********************************************************************************************
- * TMC::Message_Handler -- Message handler function for Winsock related messages               *
- *                                                                                             *
- *                                                                                             *
- *                                                                                             *
- * INPUT:    Windows message handler stuff                                                     *
- *                                                                                             *
- * OUTPUT:   Nothing                                                                           *
- *                                                                                             *
- * WARNINGS: None                                                                              *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *    3/20/96 3:05PM ST : Created                                                              *
- *=============================================================================================*/
-int UDPInterfaceClass::Message_Handler(HWND, UINT message, UINT, LONG lParam)
+/// <summary>
+/// Takes every datagram the socket holds into the in buffers. A pass is
+/// bounded so that a flood cannot hold the frame; what is left waits for the
+/// next one.
+/// </summary>
+void UDPInterfaceClass::Receive_Pending(void)
 {
-	struct 	sockaddr_in addr;
-	int	 	rc;
-	int		addr_len;
-	WinsockBufferType *packet;
+	for (int taken = 0; taken < WS_MAX_STATIC_BUFFERS; taken++) {
+		struct sockaddr_in addr;
 
-	/*
-	**	We only handle UDP events.
-	*/
-	if ( message != WM_UDPASYNCEVENT ) return(1);
+		int rc = Receive_From ( (char*)ReceiveBuffer, sizeof (ReceiveBuffer), &addr );
+		if (rc == RECEIVE_IGNORED) continue;
 
-	/*
-	**	Handle UDP packet events
-	*/
-	switch ( WSAGETSELECTEVENT(lParam) ) {
-
-		/*
-		**	Read event. Winsock has data it would like to give us.
-		*/
-		case FD_READ: {
-			/*
-			**	Clear any outstanding errors on the socket.
-			*/
-			rc = WSAGETSELECTERROR(lParam);
-			if (rc != 0) {
-				Clear_Socket_Error (Socket);
-				return(0);;
-			}
-
-			/*
-			**	Call the Winsock recvfrom function to get the outstanding packet.
-			*/
-			rc = Receive_From ( (char*)ReceiveBuffer, sizeof (ReceiveBuffer), &addr );
-			if (rc == SOCKET_ERROR) {
-				Clear_Socket_Error (Socket);
-				return(0);;
-			}
-
-			std::span<std::byte const> const datagram(reinterpret_cast<std::byte const *>(ReceiveBuffer), rc > 0 ? static_cast<std::size_t>(rc) : 0);
-			NetAdmission::DatagramResult const admission = NetAdmission::Admit_Datagram(datagram, WS_INTERNET_BUFFER_LEN);
-			if (!admission.Succeeded()) {
-				switch (admission.ErrorCode) {
-					case NetAdmission::Error::DATAGRAM_TOO_LARGE:
-						Record_Packet_Drop(WS_DROP_RECEIVE_TOO_LARGE);
-						break;
-					case NetAdmission::Error::BAD_CRC:
-						Record_Packet_Drop(WS_DROP_BAD_CRC);
-						break;
-					default:
-						Record_Packet_Drop(WS_DROP_RECEIVE_TOO_SHORT);
-						break;
-				}
-				return(0);
-			}
-
-			{
-
-				/*
-				**	Make sure this packet didn't come from us. If it did then throw it away.
-				*/
-				for ( int i=0 ; i<LocalAddresses.Count() ; i++ ) {
-					if ( ! memcmp (LocalAddresses[i], &addr.sin_addr.s_addr, 4) ) return(0);
-				}
-
-				/*
-				**	Create a new buffer and store this packet in it.
-				*/
-				packet = (WinsockBufferType *)Get_New_In_Buffer();
-				if (packet == NULL) {
-					return(0);
-				}
-				packet->BufferLen = static_cast<int>(admission.Payload.size());
-				packet->CRC = admission.WireCRC;
-				memcpy(packet->Buffer, admission.Payload.data(), admission.Payload.size());
-
-					/*
-					**	Copy the address data into the holding buffer address area.
-					*/
-					IPXAddressClass source(addr.sin_addr.s_addr, addr.sin_port);
-					memset ( packet->Address, 0, sizeof (packet->Address) );
-					memcpy ( packet->Address, &source, sizeof (source) );
-
-					/*
-					**	Add the holding buffer to the packet list.
-					*/
-					InBuffers.Add (packet);
-			}
-			return(0);
+		if (rc == SOCKET_ERROR) {
+			// The socket is empty, or it failed and the failure is cleared
+			// before the next datagram is tried.
+			if (LAST_ERROR == WSAEWOULDBLOCK) return;
+			Clear_Socket_Error (Socket);
+			continue;
 		}
 
+		std::span<std::byte const> const datagram(reinterpret_cast<std::byte const *>(ReceiveBuffer), rc > 0 ? static_cast<std::size_t>(rc) : 0);
+		NetAdmission::DatagramResult const admission = NetAdmission::Admit_Datagram(datagram, WS_INTERNET_BUFFER_LEN);
+		if (!admission.Succeeded()) {
+			switch (admission.ErrorCode) {
+				case NetAdmission::Error::DATAGRAM_TOO_LARGE:
+					Record_Packet_Drop(WS_DROP_RECEIVE_TOO_LARGE);
+					break;
+				case NetAdmission::Error::BAD_CRC:
+					Record_Packet_Drop(WS_DROP_BAD_CRC);
+					break;
+				default:
+					Record_Packet_Drop(WS_DROP_RECEIVE_TOO_SHORT);
+					break;
+			}
+			continue;
+		}
 
 		/*
-		**	Write event. We send ourselves this event when we have more data to send. This
-		**	event will also occur automatically when a packet has finished being sent.
+		**	Make sure this packet didn't come from us. If it did then throw it away.
 		*/
-		case FD_WRITE:
-			/*
-			**	Clear any outstanding erros on the socket.
-			*/
-			rc = WSAGETSELECTERROR(lParam);
-			if (rc != 0) {
-				Clear_Socket_Error (Socket);
-				return(0);;
+		bool ours = false;
+		for ( int i=0 ; i<LocalAddresses.Count() ; i++ ) {
+			if ( ! memcmp (LocalAddresses[i], &addr.sin_addr.s_addr, 4) ) {
+				ours = true;
+				break;
 			}
+		}
+		if (ours) continue;
 
-			/*
-			**	If there are no packets waiting to be sent then bail.
-			*/
-			if ( OutBuffers.Count() == 0 ) return(0);
-			int packetnum = 0;
+		/*
+		**	Create a new buffer and store this packet in it.
+		*/
+		WinsockBufferType *packet = (WinsockBufferType *)Get_New_In_Buffer();
+		if (packet == NULL) {
+			return;
+		}
+		packet->BufferLen = static_cast<int>(admission.Payload.size());
+		packet->CRC = admission.WireCRC;
+		memcpy(packet->Buffer, admission.Payload.data(), admission.Payload.size());
 
-			/*
-			**	Get a pointer to the packet.
-			*/
-			packet = OutBuffers [ packetnum ];
+		/*
+		**	Copy the address data into the holding buffer address area.
+		*/
+		IPXAddressClass source(addr.sin_addr.s_addr, addr.sin_port);
+		memset ( packet->Address, 0, sizeof (packet->Address) );
+		memcpy ( packet->Address, &source, sizeof (source) );
 
-			/*
-			**	Set up the address structure of the outgoing packet
-			*/
-			IPXAddressClass destination;
-			memcpy (&destination, packet->Address, sizeof (destination));
-
-			addr.sin_family = AF_INET;
-			addr.sin_addr.s_addr = destination.Get_IP();
-
-			// An address without a port of its own goes to the port this socket was given.
-			addr.sin_port = destination.Get_Port() != 0 ? destination.Get_Port()
-				: (unsigned short) htons ( DestinationPortSet ? DestinationPort : (unsigned short)WestwoodOnline_PortNumber );
-
-			/*
-			**	Send it.
-			**	If we get a WSAWOULDBLOCK error it means that Winsock is unable to accept the packet
-			**	at this time. In this case, we clear the socket error and just exit. Winsock will
-			**	send us another WRITE message when it is ready to receive more data.
-			*/
-			rc = Send_To ( ((char const *)packet->Buffer) - sizeof(packet->CRC), packet->BufferLen + sizeof(packet->CRC), &addr );
-
-			if (rc == SOCKET_ERROR){
-				if (LAST_ERROR != WSAEWOULDBLOCK) {
-					Clear_Socket_Error (Socket);
-					return(0);
-				}
-			}
-
-			/*
-			**	Delete the sent packet.
-			*/
-			OutBuffers.Delete_Index(0);
-			if (packet->IsAllocated) {
-				delete packet;
-			} else {
-				packet->InUse = false;
-				OutBuffersUsed--;
-			}
-			return(0);
+		/*
+		**	Add the holding buffer to the packet list.
+		*/
+		InBuffers.Add (packet);
 	}
+}
 
-	return(0);
+
+/// <summary>
+/// Sends the out buffers in order until they are empty or the socket will
+/// take no more. A packet the socket has no room for is given up, since the
+/// connection above resends what goes unacknowledged; any other failure is
+/// cleared and leaves the packet at the head for the next pass.
+/// </summary>
+void UDPInterfaceClass::Send_Pending(void)
+{
+	while ( OutBuffers.Count() > 0 ) {
+		struct sockaddr_in addr;
+		WinsockBufferType *packet = OutBuffers [ 0 ];
+
+		/*
+		**	Set up the address structure of the outgoing packet
+		*/
+		IPXAddressClass destination;
+		memcpy (&destination, packet->Address, sizeof (destination));
+
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = destination.Get_IP();
+
+		// An address without a port of its own goes to the port this socket was given.
+		addr.sin_port = destination.Get_Port() != 0 ? destination.Get_Port()
+			: (unsigned short) htons ( DestinationPortSet ? DestinationPort : (unsigned short)WestwoodOnline_PortNumber );
+
+		int rc = Send_To ( ((char const *)packet->Buffer) - sizeof(packet->CRC), packet->BufferLen + sizeof(packet->CRC), &addr );
+
+		if (rc == SOCKET_ERROR && LAST_ERROR != WSAEWOULDBLOCK) {
+			Clear_Socket_Error (Socket);
+			return;
+		}
+
+		OutBuffers.Delete_Index(0);
+		if (packet->IsAllocated) {
+			delete packet;
+		} else {
+			packet->InUse = false;
+			OutBuffersUsed--;
+		}
+	}
 }

--- a/code/wspudp.cpp
+++ b/code/wspudp.cpp
@@ -138,7 +138,9 @@ void UDPInterfaceClass::Configure_Tunnel(unsigned short local_id, unsigned long 
 /// </summary>
 /// <param name="destination">Where the packet is bound. In tunnel mode the port carries
 /// the recipient's tunnel ID rather than a real port.</param>
-/// <returns>Whatever sendto returned, counting only the payload.</returns>
+/// <returns>Whatever sendto returned, counting only the payload. A SOCKET_ERROR always
+/// leaves a matching code in LAST_ERROR, including the rejection this routine makes
+/// itself, so that a caller can tell a full socket from a packet it can never send.</returns>
 int UDPInterfaceClass::Send_To(const char *buffer, int buffer_len, sockaddr_in *destination)
 {
 	if (TunnelPort == 0) {
@@ -149,6 +151,7 @@ int UDPInterfaceClass::Send_To(const char *buffer, int buffer_len, sockaddr_in *
 	// outside the packet's own framing.
 	char tunnelled[TUNNEL_HEADER_SIZE + WS_RECEIVE_BUFFER_LEN];
 	if (buffer_len > (int)sizeof(tunnelled) - TUNNEL_HEADER_SIZE) {
+		WSASetLastError(WSAEMSGSIZE);
 		return(SOCKET_ERROR);
 	}
 
@@ -583,9 +586,8 @@ void UDPInterfaceClass::Receive_Pending(void)
 
 /// <summary>
 /// Sends the out buffers in order until they are empty or the socket will
-/// take no more. A packet the socket has no room for is given up, since the
-/// connection above resends what goes unacknowledged; any other failure is
-/// cleared and leaves the packet at the head for the next pass.
+/// take no more. A send that fails leaves its packet at the head for the next
+/// pass and ends this one, so a full socket costs a pass rather than the queue.
 /// </summary>
 void UDPInterfaceClass::Send_Pending(void)
 {
@@ -608,9 +610,13 @@ void UDPInterfaceClass::Send_Pending(void)
 
 		int rc = Send_To ( ((char const *)packet->Buffer) - sizeof(packet->CRC), packet->BufferLen + sizeof(packet->CRC), &addr );
 
-		if (rc == SOCKET_ERROR && LAST_ERROR != WSAEWOULDBLOCK) {
-			Clear_Socket_Error (Socket);
-			return;
+		if (rc == SOCKET_ERROR) {
+			// A full socket is not the packet's fault, so the packet stays queued
+			// either way. Anything else is cleared before the next pass retries it.
+			if (LAST_ERROR != WSAEWOULDBLOCK) {
+				Clear_Socket_Error (Socket);
+			}
+			break;
 		}
 
 		OutBuffers.Delete_Index(0);

--- a/code/wspudp.cpp
+++ b/code/wspudp.cpp
@@ -139,8 +139,7 @@ void UDPInterfaceClass::Configure_Tunnel(unsigned short local_id, unsigned long 
 /// <param name="destination">Where the packet is bound. In tunnel mode the port carries
 /// the recipient's tunnel ID rather than a real port.</param>
 /// <returns>Whatever sendto returned, counting only the payload. A SOCKET_ERROR always
-/// leaves a matching code in LAST_ERROR, including the rejection this routine makes
-/// itself, so that a caller can tell a full socket from a packet it can never send.</returns>
+/// sets LAST_ERROR, including for a packet this routine rejects itself.</returns>
 int UDPInterfaceClass::Send_To(const char *buffer, int buffer_len, sockaddr_in *destination)
 {
 	if (TunnelPort == 0) {
@@ -516,14 +515,14 @@ void UDPInterfaceClass::Broadcast (void *buffer, int buffer_len)
 void UDPInterfaceClass::Receive_Pending(void)
 {
 	for (int taken = 0; taken < WS_MAX_STATIC_BUFFERS; taken++) {
-		struct sockaddr_in addr;
+		sockaddr_in addr;
 
 		int rc = Receive_From ( (char*)ReceiveBuffer, sizeof (ReceiveBuffer), &addr );
 		if (rc == RECEIVE_IGNORED) continue;
 
 		if (rc == SOCKET_ERROR) {
-			// The socket is empty, or it failed and the failure is cleared
-			// before the next datagram is tried.
+			// Would-block means the socket is empty; anything else is cleared
+			// and the drain carries on.
 			if (LAST_ERROR == WSAEWOULDBLOCK) return;
 			Clear_Socket_Error (Socket);
 			continue;
@@ -561,7 +560,7 @@ void UDPInterfaceClass::Receive_Pending(void)
 		/*
 		**	Create a new buffer and store this packet in it.
 		*/
-		WinsockBufferType *packet = (WinsockBufferType *)Get_New_In_Buffer();
+		WinsockBufferType * packet = (WinsockBufferType *)Get_New_In_Buffer();
 		if (packet == NULL) {
 			return;
 		}
@@ -585,15 +584,14 @@ void UDPInterfaceClass::Receive_Pending(void)
 
 
 /// <summary>
-/// Sends the out buffers in order until they are empty or the socket will
-/// take no more. A send that fails leaves its packet at the head for the next
-/// pass and ends this one, so a full socket costs a pass rather than the queue.
+/// Sends the out buffers in order until they are empty or the socket will take
+/// no more. A send that fails leaves its packet at the head for the next pass.
 /// </summary>
 void UDPInterfaceClass::Send_Pending(void)
 {
-	while ( OutBuffers.Count() > 0 ) {
-		struct sockaddr_in addr;
-		WinsockBufferType *packet = OutBuffers [ 0 ];
+	while (OutBuffers.Count() > 0) {
+		sockaddr_in addr;
+		WinsockBufferType * packet = OutBuffers[0];
 
 		/*
 		**	Set up the address structure of the outgoing packet
@@ -611,8 +609,6 @@ void UDPInterfaceClass::Send_Pending(void)
 		int rc = Send_To ( ((char const *)packet->Buffer) - sizeof(packet->CRC), packet->BufferLen + sizeof(packet->CRC), &addr );
 
 		if (rc == SOCKET_ERROR) {
-			// A full socket is not the packet's fault, so the packet stays queued
-			// either way. Anything else is cleared before the next pass retries it.
 			if (LAST_ERROR != WSAEWOULDBLOCK) {
 				Clear_Socket_Error (Socket);
 			}

--- a/code/wspudp.h
+++ b/code/wspudp.h
@@ -48,7 +48,6 @@ class UDPInterfaceClass : public WinsockInterfaceClass {
 		UDPInterfaceClass (void);
 		virtual ~UDPInterfaceClass(void) override;
 
-		virtual int Message_Handler(HWND window, UINT message, UINT wParam, LONG lParam) override;
 		virtual bool Open_Socket ( SOCKET socketnum ) override;
 		virtual void Set_Broadcast_Address ( const IPXAddressClass &address ) override;
 		virtual void Clear_Broadcast_Addresses(void) override;
@@ -75,10 +74,6 @@ class UDPInterfaceClass : public WinsockInterfaceClass {
 			return(PROTOCOL_UDP);
 		};
 
-		virtual int Protocol_Event_Message (void) override {
-			return(WM_UDPASYNCEVENT);
-		};
-
 		virtual int Get_Num_Local_Addresses(void) override {
 			return(LocalAddresses.Count());
 		};
@@ -87,14 +82,24 @@ class UDPInterfaceClass : public WinsockInterfaceClass {
 			return(LocalAddresses[index]);
 		};
 
+	protected:
+
+		virtual void Receive_Pending(void) override;
+		virtual void Send_Pending(void) override;
+
 	private:
 
 		void Register_Local_Addresses();
 
 		/*
 		 * Wrappers around sendto/recvfrom that add and strip the tunnel routing header.
-		 * They fall through to plain Winsock when no tunnel is configured.
+		 * They fall through to plain Winsock when no tunnel is configured. Receive_From
+		 * answers RECEIVE_IGNORED for a datagram the socket delivered that was not for
+		 * this client, which a caller draining the socket passes over where SOCKET_ERROR
+		 * stops it.
 		 */
+		static constexpr int RECEIVE_IGNORED = -2;
+
 		int Send_To(const char *buffer, int buffer_len, sockaddr_in *destination);
 		int Receive_From(char *buffer, int buffer_len, sockaddr_in *source);
 

--- a/code/wspudp.h
+++ b/code/wspudp.h
@@ -91,15 +91,11 @@ class UDPInterfaceClass : public WinsockInterfaceClass {
 
 		void Register_Local_Addresses();
 
-		/*
-		 * Wrappers around sendto/recvfrom that add and strip the tunnel routing header.
-		 * They fall through to plain Winsock when no tunnel is configured. Receive_From
-		 * answers RECEIVE_IGNORED for a datagram the socket delivered that was not for
-		 * this client, which a caller draining the socket passes over where SOCKET_ERROR
-		 * stops it.
-		 */
+		// Receive_From answers this for a datagram that was not for this client, which
+		// a caller draining the socket passes over where SOCKET_ERROR stops it.
 		static constexpr int RECEIVE_IGNORED = -2;
 
+		// Wrappers around sendto/recvfrom that add and strip the tunnel routing header.
 		int Send_To(const char *buffer, int buffer_len, sockaddr_in *destination);
 		int Receive_From(char *buffer, int buffer_len, sockaddr_in *source);
 


### PR DESCRIPTION
This polls the UDP socket from the network manager's service pass instead of receiving Winsock's read and write notifications through the main window. The socket becomes non-blocking, Service drains it and flushes the send queue, and the window procedure stops routing socket messages.

This removes the transport's only dependency on a window handle and a message loop, so a platform without one (hello Linux/macOS) can supply its own carrier underneath the same code.

Tested with a LAN game.