### PR TITLE
Skip a tag without a trigger when a variable resets timers

### DIFF
--- a/code/tag.cpp
+++ b/code/tag.cpp
@@ -347,7 +347,10 @@ void TagClass::Delete_All(void)
 /// <param name="global">The global flag that just changed.</param>
 void TagClass::Timer_Global_Reset(int global)
 {
-	Trigger->Reset_Global_Linked_Timed_Events(global);
+	// A tag outlives a destroyed trigger with no link to take its place.
+	if (Trigger != nullptr) {
+		Trigger->Reset_Global_Linked_Timed_Events(global);
+	}
 }
 
 
@@ -357,7 +360,9 @@ void TagClass::Timer_Global_Reset(int global)
 /// <param name="local">The local variable that just changed.</param>
 void TagClass::Timer_Local_Reset(int local)
 {
-	Trigger->Reset_Local_Linked_Timed_Events(local);
+	if (Trigger != nullptr) {
+		Trigger->Reset_Local_Linked_Timed_Events(local);
+	}
 }
 
 

--- a/manual/changes/tag-timer-reset-without-trigger.md
+++ b/manual/changes/tag-timer-reset-without-trigger.md
@@ -1,0 +1,12 @@
+---
+title: Survive a variable change while a tag has lost its trigger
+category: fix
+release: 0.2.0
+targets:
+- type: system
+  id: trigger-springing
+  effect: changed
+credit: [gibbo101]
+---
+
+A tag whose trigger has been destroyed keeps a null trigger when the destroyed one had no linked trigger to take its place. A trigger action that set a local or global variable then restarted every tag's timed events through that null trigger and crashed the game. The reset now skips a tag without a trigger, so the action completes and the other tags' timers restart as before.


### PR DESCRIPTION
A tag whose trigger has been destroyed keeps a null `Trigger` when the destroyed trigger had no `LinkedTo` to take its place (`Detach` sets `Trigger = Trigger->LinkedTo`). A trigger action that sets a local or global variable then calls `Timer_Local_Reset` / `Timer_Global_Reset` on every tag, and the dereference through that null pointer crashes the game. This skips a tag without a trigger so the action completes and the other tags' timers restart as before.

**Behavior:** fixed. No compatibility boundary changes: no data format, save, or network representation changes; the reset runs identically on every peer.

**Validation:** hit in play on my controller fork, where this change has been running since. Built with the fork's experimental clang-cl cross build and CTest passes 18/18 there. I have not run the supported MSVC Win32 build; CI will cover it.

**Documentation:** `manual/changes/tag-timer-reset-without-trigger.md` (fix, targets the trigger springing system). `manage.py check --base-ref main` passes.