### PR TITLE
Save a pointer identity as four bytes on every host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,9 @@ elseif(MSVC)
         message(FATAL_ERROR "OpenTS requires MSVC 19.30 or newer.")
     endif()
     if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
-        # Saved games serialize pointer fields at their native width, and the packed version
-        # stamp that saves and network packets carry is the same either way.
+        # A save records pointer identities at a fixed width, but the members and raw
+        # structures around them still travel at the build's own widths, and the packed
+        # version stamp that saves and network packets carry is the same either way.
         message(WARNING
             "OpenTS: this build has ${CMAKE_SIZEOF_VOID_P}-byte pointers. Saved games it "
             "writes are not interchangeable with a supported 32-bit build's, and nothing in "

--- a/code/abstract.cpp
+++ b/code/abstract.cpp
@@ -194,7 +194,7 @@ HRESULT STDMETHODCALLTYPE AbstractClass::Load(IStream * stream)
 
 /// <summary>
 /// Writes the members this object describes out to the save stream.
-/// The object's address goes out first as its swizzle identity, and the members follow
+/// The object's swizzle identity goes out first, and the members follow
 /// in the order Serialize names them.
 /// </summary>
 /// <param name="stream">The stream to write to.</param>
@@ -206,7 +206,7 @@ HRESULT AbstractClass::Save_Members(IStream * stream, BOOL cleardirty)
 		return(E_POINTER);
 	}
 
-	uintptr_t id = (uintptr_t)this;
+	SwizzleIDType id = Swizzler.ID_Of(this);
 
 	HRESULT result = stream->Write(&id, sizeof(id), NULL);
 	if (FAILED(result)) {
@@ -226,7 +226,7 @@ HRESULT AbstractClass::Save_Members(IStream * stream, BOOL cleardirty)
 
 /// <summary>
 /// Reads the members this object describes back from the save stream.
-/// The saved address is handed to the swizzle system so that pointers elsewhere in the
+/// The saved identity is handed to the swizzle system so that pointers elsewhere in the
 /// save game can be remapped onto this object, and the members follow.
 /// </summary>
 /// <param name="stream">The stream to read from.</param>
@@ -237,7 +237,7 @@ HRESULT AbstractClass::Load_Members(IStream * stream)
 		return(E_POINTER);
 	}
 
-	uintptr_t id;
+	SwizzleIDType id;
 
 	HRESULT result = stream->Read(&id, sizeof(id), NULL);
 	if (FAILED(result)) {

--- a/code/loco.cpp
+++ b/code/loco.cpp
@@ -255,8 +255,8 @@ LONG STDMETHODCALLTYPE LocomotionClass::QueryInterface(REFIID riid, LPVOID *ppvO
 
 /// <summary>
 /// Saves the locomotor out to a save game stream.
-/// The locomotor's address is written ahead of its data, which is what lets the swizzle
-/// manager remap every pointer to it when the game is loaded again.
+/// The locomotor's swizzle identity is written ahead of its data, which is what lets the
+/// swizzle manager remap every pointer to it when the game is loaded again.
 /// </summary>
 /// <param name="cleardirty">Should the locomotor be marked as no longer needing a save?</param>
 /// <returns>Returns with the result of the write, or E_POINTER if no stream was supplied.</returns>
@@ -291,7 +291,7 @@ HRESULT STDMETHODCALLTYPE LocomotionClass::Load(IStream * stream)
 
 /// <summary>
 /// Writes the members this locomotor describes out to the save stream.
-/// The locomotor's address goes out first as its swizzle identity, and the members follow
+/// The locomotor's swizzle identity goes out first, and the members follow
 /// in the order Serialize names them.
 /// </summary>
 /// <param name="stream">The stream to write to.</param>
@@ -303,7 +303,7 @@ HRESULT LocomotionClass::Save_Members(IStream * stream, BOOL cleardirty)
 		return(E_POINTER);
 	}
 
-	uintptr_t id = (uintptr_t)(this);
+	SwizzleIDType id = Swizzler.ID_Of(this);
 
 	HRESULT result = stream->Write(&id, sizeof(id), NULL);
 	if (FAILED(result)) {
@@ -323,7 +323,7 @@ HRESULT LocomotionClass::Save_Members(IStream * stream, BOOL cleardirty)
 
 /// <summary>
 /// Reads the members this locomotor describes back from the save stream.
-/// The saved address is handed to the swizzle system so that pointers elsewhere in the
+/// The saved identity is handed to the swizzle system so that pointers elsewhere in the
 /// save game can be remapped onto this locomotor, and the members follow.
 /// </summary>
 /// <param name="stream">The stream to read from.</param>
@@ -334,7 +334,7 @@ HRESULT LocomotionClass::Load_Members(IStream * stream)
 		return(E_POINTER);
 	}
 
-	uintptr_t id;
+	SwizzleIDType id;
 
 	HRESULT result = stream->Read(&id, sizeof(id), NULL);
 	if (FAILED(result)) {

--- a/code/saveload.cpp
+++ b/code/saveload.cpp
@@ -921,6 +921,8 @@ bool Save_Game(const char *file_name, char const * descr)
 
 	DebugString("\nSAVING GAME [%s - %s]\n", file_name, descr);
 
+	Swizzler.Begin_Save();
+
 	MultiByteToWideChar(0,0, Saved_Game_Name(file_name).c_str(), -1, name, sizeof(name)/sizeof(WCHAR));
 
 	/*

--- a/code/savestream.h
+++ b/code/savestream.h
@@ -108,7 +108,7 @@ class SaveStreamClass
 		 * Names the record this stream is carrying, so that a pointer which nothing
 		 * answers for can be reported against the object that asked for it.
 		 */
-		void Set_Context(char const * ownertype, uintptr_t ownerid = 0)
+		void Set_Context(char const * ownertype, SwizzleIDType ownerid = 0)
 		{
 			OwnerType = ownertype;
 			OwnerID = ownerid;
@@ -126,17 +126,18 @@ class SaveStreamClass
 		}
 
 		/*
-		 * A pointer travels as the address the object occupied when the game was saved,
-		 * the identity it announces on the way back in. Loading leaves the slot with the
-		 * swizzle manager until the object says where it landed.
+		 * A pointer travels as the identity the object it names announces on the way back
+		 * in. Loading leaves the slot with the swizzle manager until the object says where
+		 * it landed.
 		 */
 		template<SwizzleTarget T>
 		void Serialize(T * & pointer, std::source_location const & where = std::source_location::current())
 		{
-			Serialize_Bytes((void *)&pointer, sizeof(pointer));
+			SwizzleIDType id = Is_Loading() ? 0 : Swizzler.ID_Of(pointer);
+			Serialize_Bytes(&id, sizeof(id));
 
 			if (Is_Loading() && !Was_Error()) {
-				Swizzler.Swizzle((void **)&pointer, OwnerType, OwnerID, typeid(T).name(), where.file_name(), where.line());
+				Swizzler.Swizzle((void **)&pointer, id, OwnerType, OwnerID, typeid(T).name(), where.file_name(), where.line());
 			}
 		}
 
@@ -347,7 +348,7 @@ class SaveStreamClass
 		 * Nothing on the save side needs it.
 		 */
 		char const * OwnerType;
-		uintptr_t OwnerID;
+		SwizzleIDType OwnerID;
 };
 
 

--- a/code/swizzle.cpp
+++ b/code/swizzle.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unordered_map>
 
 
 SwizzleManagerClass Swizzler;
@@ -46,6 +47,14 @@ static char const * Base_Name(char const * path)
 }
 
 
+namespace {
+
+std::unordered_map<void const *, SwizzleIDType> IDTable;
+SwizzleIDType NextID = 1;
+
+}	// namespace
+
+
 /// <summary>
 /// Constructor for the pointer swizzle manager.
 /// The request and pointer tables are given generous room up front, since a save game
@@ -59,23 +68,62 @@ SwizzleManagerClass::SwizzleManagerClass(void)
 
 
 /// <summary>
+/// Starts a fresh numbering of saved identities.
+/// </summary>
+/// <remarks>An identity only has to be unique within one saved game, so the save code
+/// calls this before it writes the first record.</remarks>
+void SwizzleManagerClass::Begin_Save(void)
+{
+	IDTable.clear();
+	NextID = 1;
+}
+
+
+/// <summary>
+/// Fetches the identity a pointer is saved under.
+/// Pointers are numbered in the order the save first meets them, so what a save holds
+/// does not depend on where the objects happened to sit in memory, or on how wide a
+/// pointer is on the host that wrote it.
+/// </summary>
+/// <param name="pointer">The pointer being written, which may be null.</param>
+/// <returns>Returns with the identity to write in the pointer's place, or zero for a
+/// null pointer.</returns>
+SwizzleIDType SwizzleManagerClass::ID_Of(void const * pointer)
+{
+	if (pointer == nullptr) {
+		return(0);
+	}
+
+	auto found = IDTable.find(pointer);
+	if (found != IDTable.end()) {
+		return(found->second);
+	}
+
+	SwizzleIDType const id = NextID++;
+	IDTable.emplace(pointer, id);
+	return(id);
+}
+
+
+/// <summary>
 /// Registers a saved pointer to be resolved later.
 /// The load code calls this routine for every pointer it reads back, since the value on
 /// disk is a swizzle ID rather than an address. The request is remembered and the pointer
 /// is cleared until the tables are resolved and the real address is known.
 /// </summary>
 /// <param name="pointer">Pointer to the pointer that needs resolving.</param>
+/// <param name="id">The identity read from the save in the pointer's place.</param>
 /// <param name="ownertype">The type of the record being read, for the failure report.</param>
 /// <param name="ownerid">The swizzle ID of the record being read.</param>
 /// <param name="slottype">The type the pointer slot names.</param>
-void SwizzleManagerClass::Swizzle(void ** pointer, char const * ownertype, uintptr_t ownerid, char const * slottype, char const * file, unsigned int line)
+void SwizzleManagerClass::Swizzle(void ** pointer, SwizzleIDType id, char const * ownertype, SwizzleIDType ownerid, char const * slottype, char const * file, unsigned int line)
 {
 	if (pointer == NULL) {
 		return;
 	}
 
-	uintptr_t id = (uintptr_t)(*pointer);
 	if (id == 0) {
+		*pointer = nullptr;
 		return;
 	}
 
@@ -93,7 +141,7 @@ void SwizzleManagerClass::Swizzle(void ** pointer, char const * ownertype, uintp
 /// </summary>
 /// <param name="id">The swizzle ID the object was saved under.</param>
 /// <param name="pointer">The address the object now resides at.</param>
-void SwizzleManagerClass::Here_I_Am(uintptr_t id, void * pointer)
+void SwizzleManagerClass::Here_I_Am(SwizzleIDType id, void * pointer)
 {
 	PointerTable.emplace_back(id, pointer);
 }
@@ -126,7 +174,7 @@ void SwizzleManagerClass::Resolve(void)
 	 */
 	for (unsigned int index = 1; index < PointerTable.size(); index++) {
 		if (PointerTable[index].ID == PointerTable[index - 1].ID) {
-			DebugString("SWIZZLE: ID %08IX was announced twice, at %p and at %p.\n",
+			DebugString("SWIZZLE: ID %08X was announced twice, at %p and at %p.\n",
 				PointerTable[index].ID, PointerTable[index - 1].Pointer, PointerTable[index].Pointer);
 		}
 	}
@@ -137,14 +185,14 @@ void SwizzleManagerClass::Resolve(void)
 	for (SwizzleRequestClass const & request : RequestTable) {
 
 		auto entry = std::lower_bound(PointerTable.begin(), PointerTable.end(), request.ID,
-			[](SwizzlePointerClass const & left, uintptr_t id) { return(left.ID < id); });
+			[](SwizzlePointerClass const & left, SwizzleIDType id) { return(left.ID < id); });
 
 		if (entry != PointerTable.end() && entry->ID == request.ID) {
-			*(uintptr_t *)request.Pointer = (uintptr_t)entry->Pointer;
+			*(void **)request.Pointer = entry->Pointer;
 			continue;
 		}
 
-		DebugString("SWIZZLE: Nothing announced ID %08IX, wanted by a %s slot in %s record %08IX, serialized at %s(%u).\n",
+		DebugString("SWIZZLE: Nothing announced ID %08X, wanted by a %s slot in %s record %08X, serialized at %s(%u).\n",
 			request.ID,
 			request.SlotType != NULL ? request.SlotType : "<unknown>",
 			request.OwnerType != NULL ? request.OwnerType : "<unknown>",
@@ -161,7 +209,7 @@ void SwizzleManagerClass::Resolve(void)
 	if (orphans > 0) {
 		char txt[512];
 		sprintf(txt, "Save game load failed!  %d pointer(s) could not be remapped.\n\n"
-			"The first names ID %08IX, wanted by a %s slot in %s record %08IX,\n"
+			"The first names ID %08X, wanted by a %s slot in %s record %08X,\n"
 			"serialized at %s(%u).\n\n"
 			"The game will now exit.",
 			orphans,

--- a/code/swizzle.h
+++ b/code/swizzle.h
@@ -14,17 +14,19 @@
 #include <stdint.h>
 #include <vector>
 
+
+// A saved identity is four bytes, and is numbered rather than taken from the address the
+// object sat at, so a save does not depend on the pointer width of the build that wrote it.
+using SwizzleIDType = uint32_t;
+
+
 class SwizzlePointerClass
 {
 	public:
-		SwizzlePointerClass(uintptr_t id = 0, void * pointer = NULL) : ID(id), Pointer(pointer) {}
+		SwizzlePointerClass(SwizzleIDType id = 0, void * pointer = nullptr) : ID(id), Pointer(pointer) {}
 
 	public:
-		/*
-		 * This is the swizzle ID the object announced itself under -- the address it
-		 * occupied when the game was saved.
-		 */
-		uintptr_t ID;
+		SwizzleIDType ID;
 
 		/*
 		 * This is where the object was loaded to.
@@ -36,7 +38,7 @@ class SwizzlePointerClass
 class SwizzleRequestClass
 {
 	public:
-		SwizzleRequestClass(uintptr_t id = 0, void * pointer = NULL, char const * ownertype = NULL, uintptr_t ownerid = 0, char const * slottype = NULL, char const * file = NULL, unsigned int line = 0) :
+		SwizzleRequestClass(SwizzleIDType id = 0, void * pointer = nullptr, char const * ownertype = nullptr, SwizzleIDType ownerid = 0, char const * slottype = nullptr, char const * file = nullptr, unsigned int line = 0) :
 			ID(id), Pointer(pointer), OwnerType(ownertype), OwnerID(ownerid), SlotType(slottype), File(file), Line(line) {}
 
 	public:
@@ -44,7 +46,7 @@ class SwizzleRequestClass
 		 * This is the swizzle ID this request asks after, and the pointer that needs
 		 * filling in once the object that ID names has announced where it landed.
 		 */
-		uintptr_t ID;
+		SwizzleIDType ID;
 		void * Pointer;
 
 		/*
@@ -55,7 +57,7 @@ class SwizzleRequestClass
 		 * carrying them costs nothing.
 		 */
 		char const * OwnerType;
-		uintptr_t OwnerID;
+		SwizzleIDType OwnerID;
 		char const * SlotType;
 		char const * File;
 		unsigned int Line;
@@ -67,8 +69,11 @@ class SwizzleManagerClass
 	public:
 		SwizzleManagerClass(void);
 
-		void Swizzle(void ** pointer, char const * ownertype = NULL, uintptr_t ownerid = 0, char const * slottype = NULL, char const * file = NULL, unsigned int line = 0);
-		void Here_I_Am(uintptr_t id, void * pointer);
+		void Begin_Save(void);
+		SwizzleIDType ID_Of(void const * pointer);
+
+		void Swizzle(void ** pointer, SwizzleIDType id, char const * ownertype = nullptr, SwizzleIDType ownerid = 0, char const * slottype = nullptr, char const * file = nullptr, unsigned int line = 0);
+		void Here_I_Am(SwizzleIDType id, void * pointer);
 
 		void Resolve(void);
 		void Discard(void);
@@ -92,7 +97,7 @@ class SwizzleManagerClass
 extern SwizzleManagerClass Swizzler;
 
 template<class T>
-inline void Swizzle_Here_I_Am(uintptr_t id, T * ptr)
+inline void Swizzle_Here_I_Am(SwizzleIDType id, T * ptr)
 {
 	Swizzler.Here_I_Am(id, (void *)ptr);
 }

--- a/code/vein.cpp
+++ b/code/vein.cpp
@@ -905,7 +905,7 @@ bool VeinholeMonsterClass::Load_All(IStream * stream)
 		 */
 		VeinholeMonsterClass * monster = new VeinholeMonsterClass();
 
-		uintptr_t id;
+		SwizzleIDType id;
 		if (FAILED(stream->Read(&id, sizeof(id), NULL))) {
 			return(false);
 		}
@@ -985,7 +985,7 @@ bool VeinholeMonsterClass::Save_All(IStream * stream)
 	}
 
 	for (int i = 0; i < monster_count; i++) {
-		uintptr_t id = (uintptr_t)VeinholeMonsters[i];
+		SwizzleIDType id = Swizzler.ID_Of(VeinholeMonsters[i]);
 		if (FAILED(stream->Write(&id, sizeof(id), NULL))) {
 			return(false);
 		}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -129,10 +129,12 @@ cmake -S . -B build/x64 -G "Visual Studio 17 2022" -A x64 -DOPENTS_EXPERIMENTAL_
 cmake --build build/x64 --config Debug
 ```
 
-Saved games serialize pointer fields at their native width, so a 64-bit build's
-saves are not interchangeable with a supported build's. The packed version stamp
-that saves and network packets carry is the same for both, so nothing rejects a
-save or a peer on that basis. Configuring the build warns about it.
+A save records pointer identities at a fixed width, but the members and raw
+structures around them still travel at the build's own widths, so a 64-bit
+build's saves are not interchangeable with a supported build's. The packed
+version stamp that saves and network packets carry is the same for both, so
+nothing rejects a save or a peer on that basis. Configuring the build warns
+about it.
 
 ## Build from Visual Studio Code
 


### PR DESCRIPTION
A save writes each object's address in place of a pointer, so its body depends on the pointer width of the build that wrote it. This sequentially numbers the objects a save meets instead: `SwizzleIDType` (`uint32_t`) wherever an identity is written or read, and `Swizzler.ID_Of(pointer)` in place of the pointer's bytes.