### PR TITLE
Remove assumptions about the width of long and of pointers

### DIFF
--- a/code/abstype.cpp
+++ b/code/abstype.cpp
@@ -21,6 +21,7 @@
 #include "savestream.h"
 #include "vector.h"
 
+#include <cinttypes>
 #include <cstdio>
 
 
@@ -47,8 +48,8 @@ AbstractTypeClass::AbstractTypeClass(char const * ininame) :
 	GivenName()
 {
 	if (ininame == NULL) {
-		char pstr[24];
-		sprintf(pstr, "%p", (void *)this);
+		char pstr[2 * sizeof(void *) + 1];
+		sprintf(pstr, "%0*" PRIXPTR, (int)(2 * sizeof(void *)), (uintptr_t)this);
 		IniName = TStringID<24>(pstr);
 	} else {
 		IniName = TStringID<24>(ininame);

--- a/code/dropship.cpp
+++ b/code/dropship.cpp
@@ -867,7 +867,7 @@ void Dropship_Screen(void)
 						--j;
 					}
 
-					int alpha = std::min(255ul, (_dissolve_rate * timeGetTime() - _dissolve_rate * effect->StartTime) / _dissolve_scale);
+					int alpha = std::min<DWORD>(255, (_dissolve_rate * timeGetTime() - _dissolve_rate * effect->StartTime) / _dissolve_scale);
 
 					if (alpha != effect->Alpha || overlap_drawn) {
 						effect->Alpha = alpha;

--- a/code/taction.h
+++ b/code/taction.h
@@ -133,7 +133,7 @@ class TActionClass : public AbstractClass
 			VoxelAnimType				VAnim;
 			CrateType					Crate;
 			bool						Bool;		// Boolean value.
-			long						Value;
+			int							Value;
 			float						Float;
 		} Data;
 


### PR DESCRIPTION
### Take the dissolve alpha minimum in DWORD rather than unsigned long

`std::min(255ul, ...)` compares a `DWORD` against an `unsigned long`. Deduction fails once those differ. No change where both are 32 bits.

### Pin the trigger action's Value field to a fixed width

`TActionClass::Data` is serialized raw into saves. `int` fixes `Value` at four bytes so the union cannot widen. Unchanged on MSVC, where `long` is already four.

### Format the generated type name the way MSVC's %p does

A type built without an INI name takes one from its address. `%p` has no portable format, so the name varies by library. Spelling out MSVC's formatting keeps today's string and makes it the same everywhere.