### PR TITLE
Apply on-disk layouts and MSVC-only options on other compilers

### DIFF
--- a/code/isotype.h
+++ b/code/isotype.h
@@ -80,6 +80,12 @@ struct IsoTileRecord
 	unsigned int IsRandomized:1;
 
 	/*
+	 * The tile file gives these flags a four byte field of their own, so the padding holds
+	 * the members below at the offsets the file puts them at.
+	 */
+	unsigned int :29;
+
+	/*
 	 * This is the number of height levels this sub-tile lifts the cell it covers, so that a
 	 * tile laid across rising ground raises each of its cells by the right amount.
 	 */

--- a/code/visualc.h
+++ b/code/visualc.h
@@ -97,24 +97,56 @@
 /// deletion of pointer to incomplete type 'X'; no destructor called
 #pragma warning(error : 4150)
 
+#endif
 
+
+#ifndef M_E
 #define M_E         2.71828182845904523536
+#endif
+#ifndef M_LOG2E
 #define M_LOG2E     1.44269504088896340736
+#endif
+#ifndef M_LOG10E
 #define M_LOG10E    0.434294481903251827651
+#endif
+#ifndef M_LN2
 #define M_LN2       0.693147180559945309417
+#endif
+#ifndef M_LN10
 #define M_LN10      2.30258509299404568402
+#endif
+#ifndef M_PI
 #define M_PI        3.14159265358979323846
+#endif
+#ifndef M_PI_2
 #define M_PI_2      1.57079632679489661923
+#endif
+#ifndef M_PI_4
 #define M_PI_4      0.785398163397448309616
+#endif
+#ifndef M_1_PI
 #define M_1_PI      0.318309886183790671538
+#endif
+#ifndef M_2_PI
 #define M_2_PI      0.636619772367581343076
+#endif
+#ifndef M_1_SQRTPI
 #define M_1_SQRTPI  0.564189583547756286948
+#endif
+#ifndef M_2_SQRTPI
 #define M_2_SQRTPI  1.12837916709551257390
+#endif
+#ifndef M_SQRT2
 #define M_SQRT2     1.41421356237309504880
+#endif
+#ifndef M_SQRT_2
 #define M_SQRT_2    0.707106781186547524401
+#endif
 
 // Single precision pi, for the float paths that would otherwise round M_PI at every use.
+#ifndef M_FPI
 #define M_FPI 3.141592654f
+#endif
 
 /*
 **	Macros to convert between degrees and radians
@@ -133,7 +165,4 @@
 
 #ifndef DEG_TO_RADF
 #define DEG_TO_RADF(x)	(((float)x)*M_PI/180.0f)
-#endif
-
-
 #endif

--- a/code/vqalib/audio.cpp
+++ b/code/vqalib/audio.cpp
@@ -131,8 +131,9 @@ long VQA_OpenAudio(VQAHandleP *vqap)
 	params.SampleRate = vqap->SampleRate;
 	params.Channels = vqap->Channels;
 	params.BitsPerSample = vqap->BitsPerSample;
-	params.Callback1 = VQA_AudioFillCallback;
-	params.Callback2 = VQA_AudioDoneCallback;
+	// AhandleInitParams carries these as void pointers and the handler casts them back.
+	params.Callback1 = (void *)VQA_AudioFillCallback;
+	params.Callback2 = (void *)VQA_AudioDoneCallback;
 
 	rc = (long)vqap->Config.AudioHandler((VQAHandle *)vqap, VQAAUDIO_OPEN, &params, sizeof(params));
 	if (rc >= VQAERR_OK || rc == VQAERR_NONE) {

--- a/code/vqalib/cmp.h
+++ b/code/vqalib/cmp.h
@@ -18,9 +18,7 @@
 
 #include <cstdint>
 
-#if defined(__WATCOMC__) || defined(_MSC_VER)
 #pragma pack(push,1)
-#endif
 
 struct _VQA_SOS_COMPRESS_INFO
 
@@ -40,8 +38,6 @@ void __cdecl VQA_sosCODECDecompressData(void *src, void *dst, unsigned short wBi
 
 //#define VQA_sosCODECDecompressData sosCODECDecompressData
 
-#if defined(__WATCOMC__) || defined(_MSC_VER)
 #pragma pack(pop)
-#endif
 
 #endif //VQACMP_H

--- a/code/vqalib/vqafile.h
+++ b/code/vqalib/vqafile.h
@@ -38,9 +38,7 @@
 
 #include "iff.h"
 
-#if defined(__WATCOMC__) || defined(_MSC_VER)
 #pragma pack(push,1)
-#endif
 
 /*---------------------------------------------------------------------------
  * STRUCTURE DEFINITIONS AND RELATED DEFINES.
@@ -99,7 +97,7 @@ typedef struct _VQAHeader {
 	 * expanded size when it is zero, so an old movie that leaves it blank
 	 * still allocates correctly.
 	 */
-	unsigned long MaxCBSize;
+	unsigned int MaxCBSize;
 
 	/*
 	 * Bytes of audio that must be loaded ahead of a seek target to prime the
@@ -107,7 +105,7 @@ typedef struct _VQAHeader {
 	 * how many frames early to start reading. When the movie carries no
 	 * VQAHDF_SNDJUMP flag and this is zero, half a second is assumed.
 	 */
-	unsigned long AudioPreload;
+	unsigned int AudioPreload;
 } VQAHeader;
 static_assert(sizeof(VQAHeader) == 42, "the VQHD chunk is 42 bytes on disk");
 
@@ -237,9 +235,7 @@ static_assert(sizeof(VQAHeader) == 42, "the VQHD chunk is 42 bytes on disk");
 #define ID_VPKZ MAKE_ID('V','P','K','Z')
 #define ID_VPDZ MAKE_ID('V','P','D','Z')
 
-#if defined(__WATCOMC__) || defined(_MSC_VER)
 #pragma pack(pop)
-#endif
 
 #endif /* VQAFILE_H */
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,26 +34,31 @@ function(opents_add_test target)
         target_compile_definitions(${target} PRIVATE ${TEST_DEFINITIONS})
     endif()
 
+    # The option spellings and the Win32 import libraries below are MSVC's, so a harness built
+    # by another compiler takes its defaults instead.
     target_compile_options(${target} PRIVATE
-        $<$<CONFIG:Debug>:/MTd>
-        $<$<CONFIG:Release>:/MT>
-        /EHsc
-        /Zc:__cplusplus
+        $<$<CXX_COMPILER_ID:MSVC>:$<$<CONFIG:Debug>:/MTd>>
+        $<$<CXX_COMPILER_ID:MSVC>:$<$<CONFIG:Release>:/MT>>
+        $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+        $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>
     )
     if(TEST_UTF8)
-        target_compile_options(${target} PRIVATE /utf-8)
+        target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
     endif()
 
     # /arch:SSE2 is the default beyond 32-bit x86 and is rejected as an unknown option
     # there, so it is only passed where it applies.
     if(TEST_FLOAT)
-        target_compile_options(${target} PRIVATE /fp:precise)
+        target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/fp:precise>)
         if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-            target_compile_options(${target} PRIVATE /arch:SSE2)
+            target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/arch:SSE2>)
         endif()
     endif()
 
-    target_link_libraries(${target} PRIVATE kernel32 user32 shell32 ${TEST_LIBRARIES})
+    if(MSVC)
+        target_link_libraries(${target} PRIVATE kernel32 user32 shell32)
+    endif()
+    target_link_libraries(${target} PRIVATE ${TEST_LIBRARIES})
 
     if(TEST_STAMP)
         add_dependencies(${target} OpenTSBuildStamp)


### PR DESCRIPTION
This improves compatibility with non-MSVC compilers and non-Windows platforms.